### PR TITLE
fix(desktop-gallery): reduce image height to 60vh for better layout

### DIFF
--- a/src/components/desktop/Gallery/DesktopGalleryItem.tsx
+++ b/src/components/desktop/Gallery/DesktopGalleryItem.tsx
@@ -31,9 +31,10 @@ export const DesktopGalleryItem = memo(function DesktopGalleryItem({
   }
 
   const imageUrl = getOptimizedImageUrl(design.image, {
-    height: 800,
-    quality: 90,
+    height: 1200, // 2x of ~600px (60vh on typical screen)
+    quality: 95,
     format: 'webp',
+    fit: 'max',
   })
 
   return (
@@ -53,8 +54,13 @@ export const DesktopGalleryItem = memo(function DesktopGalleryItem({
         <Image
           src={imageUrl}
           alt={design.title}
-          width={600}
-          height={800}
+          height={600} // Approximate 60vh in pixels
+          width={800} // Reasonable fallback width
+          style={{
+            width: 'auto', // Let CSS control the actual width
+            height: '60vh', // Match your desired CSS height
+            objectFit: 'contain',
+          }}
           priority={index < 3}
           className="desktop-gallery-img"
         />

--- a/src/styles/desktop/gallery.css
+++ b/src/styles/desktop/gallery.css
@@ -45,7 +45,7 @@
 }
 
 .desktop-gallery-img {
-  height: 75vh !important;
+  height: 60vh !important;
   width: auto !important;
   object-fit: contain;
   box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.02);


### PR DESCRIPTION
- Reduce gallery image height from 75vh to 60vh
- Update image request height to 1200px (2x display size)
- Maintain high quality (95) and auto width for aspect ratio preservation