### PR TITLE
fix: Production deployment test failures - environment-aware Lighthouse thresholds

### DIFF
--- a/tests/performance/monitoring-integration.test.ts
+++ b/tests/performance/monitoring-integration.test.ts
@@ -219,17 +219,25 @@ describe('Performance Monitoring Integration Tests', () => {
       const lighthouseConfig = await import('../../lighthouserc.js')
 
       // Issue #47: Adjusted CI thresholds for realistic expectations
+      // Issue #63: These values depend on CI environment variable
+      // In CI (GitHub Actions): CI=true triggers overrides (0.7, 3000ms)
+      // Locally: Uses base values (0.5, 5000ms)
+
+      const isCI = process.env.CI === 'true'
+      const expectedPerfScore = isCI ? 0.7 : 0.5
+      const expectedLCP = isCI ? 3000 : 5000
+
       expect(
         lighthouseConfig.default.ci.assert.assertions['categories:performance']
-      ).toEqual(['warn', { minScore: 0.5 }]) // Adjusted for CI environment
+      ).toEqual(['warn', { minScore: expectedPerfScore }])
       expect(
         lighthouseConfig.default.ci.assert.assertions[
           'largest-contentful-paint'
         ]
-      ).toEqual(['warn', { maxNumericValue: 5000 }]) // Adjusted for CI throttling
+      ).toEqual(['warn', { maxNumericValue: expectedLCP }])
       expect(
         lighthouseConfig.default.ci.assert.assertions['cumulative-layout-shift']
-      ).toEqual(['warn', { maxNumericValue: 0.25 }]) // Slightly relaxed for CI
+      ).toEqual(['warn', { maxNumericValue: 0.25 }]) // Same in both environments
     })
 
     test('should ensure monitoring overhead meets sub-1ms requirement', () => {


### PR DESCRIPTION
## Summary
- Fix production deployment pipeline test failures
- Update monitoring integration test to handle environment-specific Lighthouse threshold overrides
- Test now dynamically validates correct values for both local and CI environments

## Problem
The production deployment workflow on `master` was consistently failing because `tests/performance/monitoring-integration.test.ts` expected static threshold values that didn't account for CI environment overrides in `lighthouserc.js`.

**Test failure**:
```
Expected: minScore: 0.5
Received: minScore: 0.7
```

## Root Cause
PR #59 and #57 updated `lighthouserc.js` to override Lighthouse thresholds in CI environments (`process.env.CI`), but the integration test was checking the default exported values without considering these overrides.

## Solution
Updated test to dynamically check `process.env.CI` and validate correct thresholds:
- **CI environment** (GitHub Actions): `minScore: 0.7`, `LCP: 3000ms`
- **Local environment**: `minScore: 0.5`, `LCP: 5000ms`

## Changes
- `tests/performance/monitoring-integration.test.ts`: Added environment-aware validation logic

## Test Plan
- [x] Tests pass locally (`npm test tests/performance/monitoring-integration.test.ts`)
- [x] Tests pass with CI flag (`CI=true npm test tests/performance/monitoring-integration.test.ts`)
- [x] Pre-commit hooks pass (ESLint, Prettier, TypeScript, Jest)
- [ ] Verify GitHub Actions CI passes
- [ ] Verify production deployment workflow completes successfully

## Related
Fixes #63
Related to #48 (CI/CD improvements), #59 (Lighthouse fixes), #57 (Performance thresholds)
