### PR TITLE
fix: Update security-monitoring to use actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/security-monitoring.yml
+++ b/.github/workflows/security-monitoring.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload security report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: security-report-${{ github.run_number }}
           path: |


### PR DESCRIPTION
## Summary
- Update deprecated actions/upload-artifact@v3 to v4 in security-monitoring workflow

## Problem
Security Monitoring workflow is failing immediately due to using deprecated actions/upload-artifact@v3.

GitHub deprecated v3 as of April 2024, and workflows now automatically fail when attempting to use it.

**Error**: 
```
This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3
```

## Solution
Update to actions/upload-artifact@v4

## Changes
- `.github/workflows/security-monitoring.yml`: Line 108, v3 → v4

## Reference
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/