### PR TITLE
fix: Eliminate CLS regression from Phase 2 LCP optimization

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,7 @@ repos:
         entry: npx tsc
         language: system
         files: \.(ts|tsx)$
+        exclude: ^\.next/
         args: [--noEmit]
         pass_filenames: false
 

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -98,13 +98,14 @@ export default function Gallery({ designs }: GalleryProps) {
   const isScrollingRef = useRef(false)
   const hasRestoredRef = useRef(false)
 
-  // Hide static first image after hydration
+  // Hide static first image after hydration (visibility:hidden preserves layout)
   useEffect(() => {
     const staticFirstImage = document.querySelector(
       '[data-first-image="true"]'
     ) as HTMLElement
     if (staticFirstImage) {
-      staticFirstImage.style.display = 'none'
+      staticFirstImage.style.visibility = 'hidden'
+      staticFirstImage.style.pointerEvents = 'none'
     }
   }, [])
 

--- a/src/components/server/FirstImage.tsx
+++ b/src/components/server/FirstImage.tsx
@@ -46,6 +46,14 @@ export function FirstImage({ design }: FirstImageProps) {
       data-first-image="true"
       className="first-image-container"
       suppressHydrationWarning
+      style={{
+        position: 'absolute',
+        width: '100%',
+        height: '60vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
     >
       <img
         src={imageUrl}
@@ -56,6 +64,11 @@ export function FirstImage({ design }: FirstImageProps) {
         loading="eager"
         decoding="async"
         suppressHydrationWarning
+        style={{
+          width: 'auto',
+          height: '60vh',
+          objectFit: 'contain',
+        }}
       />
     </div>
   )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,5 @@
     "skipDefaultLibCheck": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", ".next/types/validator.ts"]
 }


### PR DESCRIPTION
## Problem

Phase 2 of Issue #51 improved LCP from 14.3s → 6.0s (58% improvement) but introduced a CLS regression:
- CLS increased: 0.00 → 0.376
- Performance score dropped: 0.72 → 0.48 (despite LCP gains)

## Root Cause

The static first image implementation used `display: none` to hide the server-rendered image after client hydration, causing layout shift as the element collapsed out of the document flow.

## Solution

Replace layout-affecting hiding with layout-preserving approach:

1. **Use `visibility: hidden`** instead of `display: none`
   - Preserves layout space (no reflow)
   - Element still occupies space but isn't visible
   - Added `pointer-events: none` to prevent interactions

2. **Add explicit dimensions** to FirstImage container
   - Absolute positioning with explicit 60vh height
   - Flexbox layout matching gallery item styling
   - Ensures consistent space reservation

3. **Configuration fixes**
   - Excluded `.next/types/validator.ts` from TypeScript checking (Next.js build artifact issue)
   - Updated pre-commit config to skip `.next/` directory

## Changes

### Code Changes
- `FirstImage.tsx`: Add absolute positioning, explicit dimensions (60vh height), flexbox layout
- `Gallery.tsx`: Replace `display: none` with `visibility: hidden` + `pointerEvents: none`

### Configuration Changes
- `tsconfig.json`: Exclude `.next/types/validator.ts` from type checking
- `.pre-commit-config.yaml`: Exclude `.next/` directory from TypeScript checks

## Expected Impact

- **CLS**: 0.376 → <0.1 (target: zero layout shift)
- **Performance Score**: 0.48 → 0.70+ (restored to pre-regression level)
- **LCP**: Maintained at ~6.0s (no regression from Phase 2 gains)

## Testing Checklist

- [x] Build successful
- [x] All tests passing
- [x] Pre-commit hooks passing
- [ ] Local Lighthouse CLS validation (<0.1)
- [ ] Production deployment CLS validation

## Related Issues

- Fixes #56
- Part of #47 (Performance fine-tuning)
- Follows #51 Phase 2 (LCP optimization)

---

**Estimated fix time**: 30 minutes (Quick win with significant score impact)