### PR TITLE
fix: Use pattern variables for bash regex compatibility

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -21,7 +21,11 @@ jobs:
           # Squash commits: "commit message (#123)"
           COMMIT_MSG="${{ github.event.head_commit.message }}"
 
-          if [[ "$COMMIT_MSG" =~ \(#[0-9]+\)\$ ]] || [[ "$COMMIT_MSG" =~ ^Merge\ pull\ request ]]; then
+          # Define regex patterns as variables (required for bash [[ =~ ]])
+          PR_NUMBER_PATTERN='\(#[0-9]+\)$'
+          MERGE_PATTERN='^Merge pull request'
+
+          if [[ "$COMMIT_MSG" =~ $PR_NUMBER_PATTERN ]] || [[ "$COMMIT_MSG" =~ $MERGE_PATTERN ]]; then
             echo "✅ PR merge detected - allowing"
             exit 0
           fi


### PR DESCRIPTION
## Problem

PR #71 is still failing on master with:
```
ERROR: Direct pushes to master are not allowed!
```

The regex pattern is not matching PR squash merge commits like:
```
fix: Escape dollar sign in regex pattern for bash compatibility (#71)
```

## Root Cause

Bash `[[ =~ ]]` requires regex patterns with special characters (escaped parentheses) to be stored in **unquoted variables** first, not used inline.

## Solution

Changed from inline patterns:
```bash
if [[ "$COMMIT_MSG" =~ \(#[0-9]+\)\$ ]]
```

To pattern variables:
```bash
PR_NUMBER_PATTERN='\(#[0-9]+\)$'
if [[ "$COMMIT_MSG" =~ $PR_NUMBER_PATTERN ]]
```

## Testing

Tested locally with actual commit messages:
```bash
COMMIT_MSG="fix: Escape dollar sign (#71)"
PR_NUMBER_PATTERN='\(#[0-9]+\)$'
[[ "$COMMIT_MSG" =~ $PR_NUMBER_PATTERN ]] && echo MATCH
# Result: MATCH ✅
```

## Impact

- Fixes master branch workflow failures
- PR merges will now be correctly recognized
- Direct pushes still blocked