### PR TITLE
fix: Check only first line of commit message for PR number

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -18,14 +18,17 @@ jobs:
         run: |
           # Allow GitHub's PR merge commits (both merge and squash)
           # Merge commits: "Merge pull request #123..."
-          # Squash commits: "commit message (#123)"
+          # Squash commits: "commit message (#123)" (first line only)
           COMMIT_MSG="${{ github.event.head_commit.message }}"
+
+          # Extract first line only (GitHub includes full commit body)
+          FIRST_LINE=$(echo "$COMMIT_MSG" | head -n 1)
 
           # Define regex patterns as variables (required for bash [[ =~ ]])
           PR_NUMBER_PATTERN='\(#[0-9]+\)$'
           MERGE_PATTERN='^Merge pull request'
 
-          if [[ "$COMMIT_MSG" =~ $PR_NUMBER_PATTERN ]] || [[ "$COMMIT_MSG" =~ $MERGE_PATTERN ]]; then
+          if [[ "$FIRST_LINE" =~ $PR_NUMBER_PATTERN ]] || [[ "$FIRST_LINE" =~ $MERGE_PATTERN ]]; then
             echo "✅ PR merge detected - allowing"
             exit 0
           fi


### PR DESCRIPTION
## Problem

The branch protection workflow continues to fail on master after PR merges. Analysis of the workflow logs shows the commit message is **multi-line** and includes the full commit body:

```
COMMIT_MSG="fix: Use pattern variables (#72)

The inline regex patterns were not matching...
Bash [[ =~ ]] requires regex patterns...
..."
```

The regex pattern `\(#[0-9]+\)$` uses the `$` anchor to match end-of-string, but since the message has multiple lines, the pattern fails to match.

## Solution

Extract only the first line before pattern matching:

```bash
FIRST_LINE=$(echo "$COMMIT_MSG" | head -n 1)
if [[ "$FIRST_LINE" =~ $PR_NUMBER_PATTERN ]]
```

## Testing

Tested locally with actual multi-line commit message:
```bash
COMMIT_MSG="fix: Pattern test (#72)

Full commit body here..."

FIRST_LINE=$(echo "$COMMIT_MSG" | head -n 1)
# Result: "fix: Pattern test (#72)"

PR_NUMBER_PATTERN='\(#[0-9]+\)$'
[[ "$FIRST_LINE" =~ $PR_NUMBER_PATTERN ]]
# Result: MATCH ✅
```

## Impact

- Fixes persistent master branch workflow failures
- PR merges will now be correctly recognized
- Direct pushes still blocked