### PR TITLE
fix: hide FirstImage component on mobile devices

### DIFF
--- a/src/styles/mobile/gallery.css
+++ b/src/styles/mobile/gallery.css
@@ -359,15 +359,19 @@
 /* Remove dark mode support to prevent black background */
 /* Commented out the dark mode section that was causing the black background */
 
-/* FirstImage static LCP optimization - Issue #51 Phase 2 */
+/* FirstImage static LCP optimization - Issue #51 Phase 2
+   IMPORTANT: FirstImage is desktop-only optimization, hide on mobile
+   Mobile gallery handles its own image loading and LCP optimization */
 .first-image-container {
+  /* Hide FirstImage on mobile - it's designed for desktop horizontal gallery only
+     Mobile gallery Item 1 handles first image with proper mobile optimization */
+  display: none !important;
   width: 100%;
   margin-bottom: 0;
   z-index: 1;
   pointer-events: none;
   aspect-ratio: 4/3;
   position: relative;
-  display: block;
 }
 
 .first-image-container img {


### PR DESCRIPTION
Fixes production issue where FirstImage overlaps with mobile gallery first item.

## Problem
- First gallery item on mobile shows broken image icon and alt text
- FirstImage component (desktop LCP optimization) rendering on mobile
- Overlapping with mobile gallery's first item
- Shows question mark icon due to double rendering

## Root Cause
- FirstImage designed for desktop horizontal gallery only
- Renders in server HTML for all devices (for LCP optimization)
- No logic to hide it on mobile devices
- Mobile gallery now handles its own first-image optimization

## Solution  
- Hide FirstImage on mobile via CSS (`display: none !important`)
- Mobile gallery Item 1 provides proper mobile-optimized first image
- Desktop gallery continues to benefit from FirstImage LCP optimization

## Testing
✅ Production build successful
✅ CSS-only change (no JS changes needed)

## Result
- First gallery item displays correctly on mobile
- No overlapping images or broken icons
- Desktop LCP optimization maintained

Fixes production UX issue reported by Doctor Hubert.