### PR TITLE
refactor: remove year from mobile gallery display

### DIFF
--- a/src/components/mobile/Gallery/MobileGalleryItem.tsx
+++ b/src/components/mobile/Gallery/MobileGalleryItem.tsx
@@ -128,7 +128,7 @@ export default function MobileGalleryItem({
         {design.description && (
           <p className="mobile-gallery-description">{design.description}</p>
         )}
-        {design.year && <p className="mobile-gallery-year">{design.year}</p>}
+        {/* Year removed per Doctor Hubert's request - keep only title on homepage gallery */}
         {design.category && (
           <p className="mobile-gallery-category">{design.category}</p>
         )}

--- a/src/components/mobile/Gallery/__tests__/MobileGalleryItem.test.tsx
+++ b/src/components/mobile/Gallery/__tests__/MobileGalleryItem.test.tsx
@@ -239,13 +239,14 @@ describe('MobileGalleryItem', () => {
   })
 
   describe('Metadata Display', () => {
-    it('should display year when available', () => {
+    it('should not display year (removed per Doctor Hubert request)', () => {
       render(<MobileGalleryItem design={mockSingleDesign} />)
 
+      // Year should NOT be displayed on gallery page (only title shown)
       if (mockSingleDesign.year) {
         expect(
-          screen.getByText(mockSingleDesign.year.toString())
-        ).toBeInTheDocument()
+          screen.queryByText(mockSingleDesign.year.toString())
+        ).not.toBeInTheDocument()
       }
     })
 


### PR DESCRIPTION
Simplifies mobile gallery homepage by removing year metadata.

## Change
**Before**: Title + Description + Year + Category  
**After**: Title + Description + Category

## Why
- Cleaner, more minimal homepage presentation
- Year information is redundant on browse view
- Year still available on individual project detail pages
- Matches desktop gallery (which only shows title)

## Changes Made
- Removed year display from `MobileGalleryItem` component
- Updated test to verify year is NOT displayed
- Desktop gallery already minimal (no changes needed)

## Testing
✅ All tests passing (23/23)
✅ Production build successful
✅ Test updated to verify year removal

## Result
- Cleaner, more focused gallery cards
- Only essential info shown on homepage
- Better visual hierarchy (title is primary)

Requested by Doctor Hubert for cleaner homepage presentation.