### PR TITLE
style: remove rounded corners from mobile gallery images

### DIFF
--- a/src/styles/mobile/gallery.css
+++ b/src/styles/mobile/gallery.css
@@ -25,7 +25,7 @@
     opacity 0.2s ease,
     transform 0.2s ease;
   outline: none;
-  border-radius: 4px;
+  border-radius: 0; /* Sharp corners per Doctor Hubert's request */
   overflow: hidden;
 }
 
@@ -45,7 +45,7 @@
   width: 100%;
   position: relative;
   overflow: hidden;
-  border-radius: 4px;
+  border-radius: 0; /* Sharp corners per Doctor Hubert's request */
   background-color: #f5f5f5; /* Loading state background */
 }
 


### PR DESCRIPTION
Changes mobile gallery images from rounded to sharp corners for cleaner aesthetic.

## Change
**Before**: Images with 4px rounded corners  
**After**: Images with sharp (0px) corners

## Changes Made
- `.mobile-gallery-item`: border-radius 4px → 0
- `.mobile-gallery-image-container`: border-radius 4px → 0
- Desktop gallery already has sharp corners (unchanged)

## Why
- More editorial/gallery aesthetic
- Cleaner, more professional look
- Matches desktop gallery styling
- Sharp corners are more contemporary

## Testing
✅ Production build successful
✅ CSS-only change (2 lines modified)
✅ No functional changes

## Result
- Clean, sharp-edged gallery images
- Consistent styling between mobile and desktop
- More refined visual presentation

Requested by Doctor Hubert for cleaner visual presentation.