### PR TITLE
docs: add CODEOWNERS file for PR routing (Issue #117)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,32 @@
+# CODEOWNERS
+# This file defines individuals or teams responsible for code in the repository.
+# Pull requests will automatically request reviews from relevant owners.
+#
+# Documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything in the repo
+* @maxrantil
+
+# Documentation files
+*.md @maxrantil
+/docs/ @maxrantil
+
+# Configuration files
+/.github/ @maxrantil
+*.config.* @maxrantil
+*.json @maxrantil
+
+# Security-related files
+/SECURITY.md @maxrantil
+/CODE_OF_CONDUCT.md @maxrantil
+/.github/workflows/ @maxrantil
+
+# Source code
+/src/ @maxrantil
+/pages/ @maxrantil
+
+# Tests
+/tests/ @maxrantil
+/e2e/ @maxrantil
+*.test.* @maxrantil
+*.spec.* @maxrantil


### PR DESCRIPTION
## Summary
- Add .github/CODEOWNERS for automatic PR review assignment
- Routes all PR reviews to @maxrantil
- Improves repository governance and workflow

## Changes
- **Added**: .github/CODEOWNERS with comprehensive path patterns
- **Ownership**: All paths assigned to @maxrantil
- **Coverage**: Documentation, source code, tests, config files, security files

## Test Plan
- [x] CODEOWNERS file created in correct location
- [x] Path patterns defined for all major file types
- [x] Pre-commit hooks passed

## Related
- Fixes #117
- Session: SESSION-HANDOFF-POST-LAUNCH-VALIDATION-2025-11-02.md

**Impact**: +0.05 repository health score