### PR TITLE
fix: properly activate nvm for Node v22 in production deployment

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -156,7 +156,9 @@ jobs:
 
             # Use Node.js v22 from NVM installation
             echo "🔍 Setting up Node.js v22 from NVM..."
-            export PATH="$HOME/.nvm/versions/node/v22.16.0/bin:$PATH"
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            nvm use 22 || nvm use default
 
             # Verify Node.js version
             echo "🔍 Node.js version:"


### PR DESCRIPTION
## Issue
Production deployment was using Node v18.16.0 instead of v22.16.0, causing dependency warnings:
- `sanity@4.10.2` requires Node >=20.19
- `groq@4.10.2` requires Node >=20.19
- Health API endpoint returning "Invalid body"

## Root Cause
The deployment script was only setting PATH but not properly activating nvm:
```bash
# Old (broken):
export PATH="$HOME/.nvm/versions/node/v22.16.0/bin:$PATH"

# New (fixed):
export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
nvm use 22 || nvm use default
```

## Changes
- Replace PATH export with proper nvm initialization
- Ensures both `node` and `npm` use Node v22
- Fixes dependency version warnings

## Testing
- Server confirmed to have Node v22.16.0 installed
- Will validate after merge with production deployment

## Related
Discovered during repository health sprint PRs #120-#127 merges.