### PR TITLE
fix: always run npm ci in production deployments

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -137,13 +137,9 @@ jobs:
             git fetch origin
             git reset --hard origin/master
 
-            # Install dependencies (only if package.json changed)
-            if git diff HEAD~1 --name-only | grep -q "package.json\|package-lock.json"; then
-              echo "📦 Installing dependencies..."
-              npm ci
-            else
-              echo "⏭️ No dependency changes, skipping npm ci"
-            fi
+            # Always install dependencies to ensure Node version compatibility
+            echo "📦 Installing dependencies..."
+            npm ci
 
             # Create production environment file
             echo "📝 Setting up production environment..."


### PR DESCRIPTION
## Summary
Removes conditional dependency installation logic that could leave incompatible node_modules when Node version changes.

## Problem
The deployment script was checking if package.json changed and skipping `npm ci` if not. This caused deployment failures when:
- Node version changed (e.g., from v18 to v22)
- But package.json didn't change
- Leaving node_modules incompatible with the new Node version

This resulted in errors like `sh: 1: next: not found` during builds.

## Solution
Always run `npm ci` in production deployments to ensure dependencies are compatible with the active Node version.

## Trade-offs
- Adds ~30-60s to deployment time
- Eliminates risk of incompatible node_modules
- Simpler deployment logic

## Testing
- [ ] CI pipeline passes
- [ ] Production deployment succeeds with Node v22
- [ ] Site remains functional after deployment

## Related
- Fixes deployment failure after PR #128
- Follows up on Node v22 activation improvements