### PR TITLE
fix: add missing permissions to reusable workflow jobs

### DIFF
--- a/.github/workflows/issue-validation.yml
+++ b/.github/workflows/issue-validation.yml
@@ -9,16 +9,24 @@ on:
 jobs:
   ai-attribution:
     name: Block AI Attribution in Issues
+    permissions:
+      issues: write
     uses: maxrantil/.github/.github/workflows/issue-ai-attribution-check-reusable.yml@master
 
   format-check:
     name: Check Issue Format
+    permissions:
+      issues: write
     uses: maxrantil/.github/.github/workflows/issue-format-check-reusable.yml@master
 
   prd-reminder:
     name: PRD/PDR Reminder
+    permissions:
+      issues: write
     uses: maxrantil/.github/.github/workflows/issue-prd-reminder-reusable.yml@master
 
   auto-label:
     name: Auto-label Issues
+    permissions:
+      issues: write
     uses: maxrantil/.github/.github/workflows/issue-auto-label-reusable.yml@master

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -10,12 +10,16 @@ on:
 jobs:
   pr-title:
     name: Check PR Title
+    permissions:
+      pull-requests: read
     uses: maxrantil/.github/.github/workflows/pr-title-check-reusable.yml@master
     with:
       allowed-types: 'feat,fix,docs,style,refactor,test,chore,perf,ci,build'
 
   commit-format:
     name: Check Commit Format
+    permissions:
+      contents: read
     uses: maxrantil/.github/.github/workflows/conventional-commit-check-reusable.yml@master
     with:
       base-branch: 'master'
@@ -23,6 +27,9 @@ jobs:
 
   ai-attribution:
     name: Block AI Attribution
+    permissions:
+      contents: read
+      pull-requests: read
     uses: maxrantil/.github/.github/workflows/block-ai-attribution-reusable.yml@master
     with:
       base-branch: 'master'
@@ -41,6 +48,8 @@ jobs:
 
   session-handoff:
     name: Verify Session Handoff
+    permissions:
+      contents: read
     uses: maxrantil/.github/.github/workflows/session-handoff-check-reusable.yml@master
     with:
       base-branch: 'master'


### PR DESCRIPTION
## Summary
Fixes #145

Resolves GitHub Actions workflow startup failures caused by missing permission grants when calling reusable workflows from `maxrantil/.github`.

## Problem
Multiple workflows were failing with `startup_failure`:
- **PR Validation** - all jobs requiring permissions
- **Issue Validation** - all jobs requiring permissions

**Error**: `The workflow is requesting 'pull-requests: read', but is only allowed 'pull-requests: none'.`

## Changes
Added explicit `permissions:` blocks to all jobs that call reusable workflows:

### pr-validation.yml
- **pr-title**: Added `pull-requests: read`
- **commit-format**: Added `contents: read`
- **ai-attribution**: Added `contents: read` and `pull-requests: read`
- **session-handoff**: Added `contents: read`
- **commit-quality**: Already had correct permissions ✓

### issue-validation.yml
- **ai-attribution**: Added `issues: write`
- **format-check**: Added `issues: write`
- **prd-reminder**: Added `issues: write`
- **auto-label**: Added `issues: write`

## Testing
- Pre-commit hooks: ✅ Passed
- This PR will validate the fix by running the workflows with proper permissions

## Impact
- ✅ Stops email spam from failed workflow runs
- ✅ Enables proper PR/issue validation
- ✅ Ensures CI checks run correctly
- ✅ Prevents false-negative blocking of PRs

## Note on Production Deployment Failures
The production deployment failures mentioned in #145 appear to be separate issues related to actual deployment execution, not permissions. Those should be investigated separately if they persist.