### PR TITLE
fix: remove duplicate Escape key handler (Issue #153)

### DIFF
--- a/src/components/ClientProjectContent.tsx
+++ b/src/components/ClientProjectContent.tsx
@@ -4,7 +4,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { notFound, useRouter } from 'next/navigation'
+import { notFound } from 'next/navigation'
 import { TextileDesign } from '@/types/textile'
 import { ProjectContent } from '@/app/project/[slug]/components/project-content'
 
@@ -13,7 +13,6 @@ interface ClientProjectContentProps {
 }
 
 export function ClientProjectContent({ slug }: ClientProjectContentProps) {
-  const router = useRouter()
   const [project, setProject] = useState<TextileDesign | null>(null)
   const [nextProject, setNextProject] = useState<
     | {
@@ -75,19 +74,6 @@ export function ClientProjectContent({ slug }: ClientProjectContentProps) {
 
     fetchProject()
   }, [slug])
-
-  // Escape key navigation back to gallery
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault()
-        router.push('/')
-      }
-    }
-
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [router])
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
Fixes #153 - Removes duplicate Escape key event handler that was causing navigation conflicts in E2E tests.

## Problem
The keyboard navigation workflow test was failing because two components were both listening for the Escape key:
1. ClientProjectContent.tsx - used router.push
2. DesktopImageCarousel.tsx (via useKeyboardNavigation hook) - used router.back

When Escape was pressed, both handlers fired, creating a race condition that caused the test timeout.

## Solution
- Removed redundant Escape key handler from ClientProjectContent.tsx (lines 79-90)
- Removed unused useRouter import
- Keyboard navigation is now handled solely by the useKeyboardNavigation hook in DesktopImageCarousel

## Testing
- CI will run E2E tests to verify keyboard navigation workflow passes
- Fix tested locally by removing duplicate handler and validating single navigation path

## Files Changed
- src/components/ClientProjectContent.tsx: Removed duplicate Escape handler

Closes #153