### PR TITLE
feat: Enable Umami analytics tracking

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -195,11 +195,11 @@ function addSecurityHeaders(
   // Build CSP directives
   const cspDirectives: string[] = [
     `default-src 'self'`,
-    `script-src 'self' 'nonce-${nonce}' ${isDevelopment ? "'unsafe-eval'" : ''} https://cdn.sanity.io https://www.googletagmanager.com https://www.google-analytics.com`,
+    `script-src 'self' 'nonce-${nonce}' ${isDevelopment ? "'unsafe-eval'" : ''} https://cdn.sanity.io https://www.googletagmanager.com https://www.google-analytics.com https://analytics.idaromme.dk`,
     `style-src 'self' 'nonce-${nonce}' 'unsafe-inline' https://fonts.googleapis.com`,
     `img-src 'self' data: blob: https://cdn.sanity.io https://*.googleusercontent.com https://www.google-analytics.com`,
     `font-src 'self' data: https://fonts.gstatic.com`,
-    `connect-src 'self' https://cdn.sanity.io https://www.google-analytics.com https://analytics.google.com ${isDevelopment ? 'ws://localhost:*' : ''}`,
+    `connect-src 'self' https://cdn.sanity.io https://www.google-analytics.com https://analytics.google.com https://analytics.idaromme.dk ${isDevelopment ? 'ws://localhost:*' : ''}`,
     `media-src 'self' https://cdn.sanity.io`,
     `object-src 'none'`,
     `child-src 'self'`,


### PR DESCRIPTION
## Summary
- Added Umami analytics support to Content Security Policy
- Configured environment variables for analytics.idaromme.dk
- Enables privacy-friendly visitor tracking on production site

## Changes
- **src/middleware.ts**: Added `https://analytics.idaromme.dk` to CSP `script-src` and `connect-src` directives
- **.env.local** (local only): Added `NEXT_PUBLIC_UMAMI_URL` and `NEXT_PUBLIC_UMAMI_WEBSITE_ID`

## Testing
- ✅ CSP allows Umami script loading
- ✅ Environment variables configured locally
- ⏳ Production deployment pending

## Deployment Notes
After merging, update production `.env.local` on Vultr server with:
```bash
NEXT_PUBLIC_UMAMI_URL=https://analytics.idaromme.dk
NEXT_PUBLIC_UMAMI_WEBSITE_ID=caa54504-d542-4ccc-893f-70b6eb054036
```

Then rebuild and restart:
```bash
cd /var/www/idaromme.dk
npm run build
pm2 restart idaromme
```