### PR TITLE
fix: Add Umami analytics to deployment workflow

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -67,6 +67,8 @@ jobs:
           NEXT_PUBLIC_SANITY_PROJECT_ID=${{ secrets.NEXT_PUBLIC_SANITY_PROJECT_ID }}
           NEXT_PUBLIC_SANITY_DATASET=production
           NEXT_PUBLIC_SANITY_API_VERSION=2023-05-03
+          NEXT_PUBLIC_UMAMI_URL=${{ secrets.NEXT_PUBLIC_UMAMI_URL }}
+          NEXT_PUBLIC_UMAMI_WEBSITE_ID=${{ secrets.NEXT_PUBLIC_UMAMI_WEBSITE_ID }}
           SECURITY_ENABLED=false
           EOF
       - name: Debug environment variables
@@ -75,18 +77,24 @@ jobs:
           echo "NEXT_PUBLIC_SANITY_PROJECT_ID: ${NEXT_PUBLIC_SANITY_PROJECT_ID:-'NOT SET'}"
           echo "NEXT_PUBLIC_SANITY_DATASET: ${NEXT_PUBLIC_SANITY_DATASET:-'NOT SET'}"
           echo "NEXT_PUBLIC_SANITY_API_VERSION: ${NEXT_PUBLIC_SANITY_API_VERSION:-'NOT SET'}"
+          echo "NEXT_PUBLIC_UMAMI_URL: ${NEXT_PUBLIC_UMAMI_URL:-'NOT SET'}"
+          echo "NEXT_PUBLIC_UMAMI_WEBSITE_ID: ${NEXT_PUBLIC_UMAMI_WEBSITE_ID:-'NOT SET'}"
           echo "NODE_ENV: ${NODE_ENV:-'NOT SET'}"
           echo "SECURITY_ENABLED: ${SECURITY_ENABLED:-'NOT SET'}"
         env:
           NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_SANITY_PROJECT_ID }}
           NEXT_PUBLIC_SANITY_DATASET: production
           NEXT_PUBLIC_SANITY_API_VERSION: 2023-05-03
+          NEXT_PUBLIC_UMAMI_URL: ${{ secrets.NEXT_PUBLIC_UMAMI_URL }}
+          NEXT_PUBLIC_UMAMI_WEBSITE_ID: ${{ secrets.NEXT_PUBLIC_UMAMI_WEBSITE_ID }}
           SECURITY_ENABLED: false
       - name: Build application
         env:
           NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_SANITY_PROJECT_ID }}
           NEXT_PUBLIC_SANITY_DATASET: production
           NEXT_PUBLIC_SANITY_API_VERSION: 2023-05-03
+          NEXT_PUBLIC_UMAMI_URL: ${{ secrets.NEXT_PUBLIC_UMAMI_URL }}
+          NEXT_PUBLIC_UMAMI_WEBSITE_ID: ${{ secrets.NEXT_PUBLIC_UMAMI_WEBSITE_ID }}
           SECURITY_ENABLED: false
         run: npm run build
       - name: Verify build output
@@ -154,6 +162,8 @@ jobs:
             NEXT_PUBLIC_SANITY_PROJECT_ID=${{ secrets.NEXT_PUBLIC_SANITY_PROJECT_ID }}
             NEXT_PUBLIC_SANITY_DATASET=production
             NEXT_PUBLIC_SANITY_API_VERSION=2023-05-03
+            NEXT_PUBLIC_UMAMI_URL=${{ secrets.NEXT_PUBLIC_UMAMI_URL }}
+            NEXT_PUBLIC_UMAMI_WEBSITE_ID=${{ secrets.NEXT_PUBLIC_UMAMI_WEBSITE_ID }}
             SECURITY_ENABLED=false
             EOF
 


### PR DESCRIPTION
## Summary
Fixes analytics not working in production by adding Umami environment variables to deployment workflow.

## Problem
The deployment workflow was creating `.env.local` without Umami variables, causing them to be overwritten on every deploy. This prevented the analytics script from being injected into the production build.

## Solution
Updated `.github/workflows/production-deploy.yml` to include:
- `NEXT_PUBLIC_UMAMI_URL`
- `NEXT_PUBLIC_UMAMI_WEBSITE_ID`

In all three locations:
1. Build job `.env.local` creation
2. Build environment variables
3. Deploy job `.env.local` creation

## Required Action BEFORE Merging

**⚠️ IMPORTANT: Add these GitHub Secrets first:**

Go to: https://github.com/maxrantil/textile-showcase/settings/secrets/actions

Add two new secrets:

1. **NEXT_PUBLIC_UMAMI_URL**
   - Value: `https://analytics.idaromme.dk`

2. **NEXT_PUBLIC_UMAMI_WEBSITE_ID**
   - Value: `caa54504-d542-4ccc-893f-70b6eb054036`

## Testing Plan
After merging and deploying:
1. Visit https://idaromme.dk
2. Check browser DevTools → Network tab for `analytics.idaromme.dk/script.js`
3. Verify no CSP errors in Console
4. Check Umami dashboard for visitor tracking

## Files Changed
- `.github/workflows/production-deploy.yml` - Added Umami variables to deployment

## Deployment Impact
Next push to master will automatically deploy with analytics enabled.