### PR TITLE
fix: Set NODE_ENV=production for analytics

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -82,6 +82,7 @@ jobs:
           echo "NODE_ENV: ${NODE_ENV:-'NOT SET'}"
           echo "SECURITY_ENABLED: ${SECURITY_ENABLED:-'NOT SET'}"
         env:
+          NODE_ENV: production
           NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_SANITY_PROJECT_ID }}
           NEXT_PUBLIC_SANITY_DATASET: production
           NEXT_PUBLIC_SANITY_API_VERSION: 2023-05-03
@@ -90,6 +91,7 @@ jobs:
           SECURITY_ENABLED: false
       - name: Build application
         env:
+          NODE_ENV: production
           NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_SANITY_PROJECT_ID }}
           NEXT_PUBLIC_SANITY_DATASET: production
           NEXT_PUBLIC_SANITY_API_VERSION: 2023-05-03


### PR DESCRIPTION
## Summary
Fixes analytics not loading by setting `NODE_ENV=production` during build.

## Root Cause
The `AnalyticsProvider` component checks:
```typescript
if (process.env.NODE_ENV !== 'production' || !process.env.NEXT_PUBLIC_UMAMI_URL) {
  return  // Don't load analytics
}
```

Without `NODE_ENV=production`, the component returns early and never injects the Umami script, even though the UMAMI environment variables were correctly set.

## Solution
Add `NODE_ENV: production` to both:
1. Debug environment variables step (for verification logging)
2. Build application step (actual build process)

## Before vs After

**Before:**
```
NODE_ENV: 'NOT SET'           ❌
NEXT_PUBLIC_UMAMI_URL: ***    ✅
```
→ Analytics script NOT injected

**After:**
```
NODE_ENV: production          ✅  
NEXT_PUBLIC_UMAMI_URL: ***    ✅
```
→ Analytics script injected ✅

## Testing Plan
After merge, verify:
1. `curl -s https://idaromme.dk | grep analytics.idaromme.dk` returns script tag
2. Browser DevTools → Network shows `script.js` loading
3. Umami dashboard shows visitor tracking

## Related
- Fixes #185 (analytics variables added but not working)