### PR TITLE
fix(typography): Desktop gallery titles - Nordic Minimalism (#251)

### DIFF
--- a/src/components/desktop/Gallery/Gallery.tsx
+++ b/src/components/desktop/Gallery/Gallery.tsx
@@ -79,7 +79,7 @@ const GalleryItem = memo(function GalleryItem({
       </div>
 
       <div className="desktop-gallery-info">
-        <h2>{design.title}</h2>
+        <h2 className="desktop-gallery-title">{design.title}</h2>
       </div>
     </div>
   )

--- a/src/styles/desktop/gallery.css
+++ b/src/styles/desktop/gallery.css
@@ -57,7 +57,7 @@
   padding: 0 4px;
 }
 
-.desktop-gallery-info h3 {
+.desktop-gallery-title {
   font-size: 16px;
   font-weight: 300;
   margin: 0 0 4px 0;

--- a/src/styles/mobile/gallery.css
+++ b/src/styles/mobile/gallery.css
@@ -186,6 +186,25 @@
   margin: 0;
 }
 
+.mobile-gallery-description {
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #666;
+  margin: 8px 0 0 0;
+  letter-spacing: 0.2px;
+}
+
+.mobile-gallery-category {
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.4;
+  color: #999;
+  margin: 6px 0 0 0;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
 /* Responsive Adjustments */
 @media (max-width: 480px) {
   .mobile-gallery-stack {
@@ -200,6 +219,14 @@
 
   .mobile-gallery-title {
     font-size: 13px;
+  }
+
+  .mobile-gallery-description {
+    font-size: 13px;
+  }
+
+  .mobile-gallery-category {
+    font-size: 11px;
   }
 
   .loading-spinner {


### PR DESCRIPTION
## Summary

- Fix desktop gallery title size: 20-32px → 16px (intended size)
- Add explicit `.desktop-gallery-title` class to resolve h2/h3 CSS mismatch
- Add missing styles for `.mobile-gallery-description` and `.mobile-gallery-category`
- Include responsive breakpoints for mobile typography

## Root Cause

The component used `<h2>` but CSS targeted `.desktop-gallery-info h3`, causing titles to inherit global h2 styles (`clamp(20px, 3.5vw, 32px)`) instead of the intended 16px.

## Changes

| File | Change |
|------|--------|
| `Gallery.tsx` | Add `.desktop-gallery-title` class to h2 |
| `gallery.css` (desktop) | Target `.desktop-gallery-title` instead of `h3` |
| `gallery.css` (mobile) | Add description/category styles with responsive breakpoints |

## Nordic Minimalism Compliance

- ✅ Restrained typography (16px titles vs 32px before)
- ✅ Consistent with mobile gallery approach (class-based styling)
- ✅ WCAG compliant heading hierarchy (h2 preserved)

## Test Plan

- [x] Build passes
- [x] All tests pass (903 tests)
- [x] Pre-commit hooks pass
- [ ] Visual check at 320px, 768px, 1024px, 1920px viewports
- [ ] Cross-browser verification (Safari, Chrome, Firefox)

Fixes #251