### PR TITLE
docs: Session handoff 2026-02-28 — production stable, architectural bug documented

### DIFF
--- a/SESSION_HANDOVER.md
+++ b/SESSION_HANDOVER.md
@@ -1,334 +1,124 @@
-# Session Handoff: CRITICAL Performance Regression - Project Pages Timeout
+# Session Handoff: Production Stabilisation & Architectural Issue Found
 
-**Date**: 2026-01-18
-**Status**: 🚨 CRITICAL PRODUCTION ISSUE - Requires immediate debugging
-**Current State**: VPS at commit 9338adc (testing old code), Next.js running on PORT 3001
-
----
-
-## 🚨 CRITICAL ISSUE SUMMARY
-
-**Problem**: Project pages experience progressive performance degradation leading to complete timeout.
-
-**Pattern Observed:**
-- ✅ **1st project page**: Loads successfully
-- ⚠️ **2nd project page**: Slow (2-3 minutes)
-- ❌ **3rd+ project pages**: Complete timeout (NS_ERROR_TIMING in browser)
-
-**Key Finding**: This issue occurs on **BOTH** current code (796e891) AND old code (9338adc - before Issue #266 work), proving **Issue #266 crossOrigin fix is NOT the cause**.
+**Date**: 2026-02-28
+**Branch**: `master` (clean)
+**Commit**: `5c7a696`
 
 ---
 
-## 📊 Current VPS State
+## ✅ Completed This Session
 
-**Git Status:**
-```bash
-HEAD detached at 9338adc
-Commit: 9338adc test: Skip analytics tests while analytics is disabled (#265)
-Date: 2026-01-02 (before crossOrigin work)
-```
+### 1. Repo Cleaned Up & Ready for New Work
+- Committed outstanding `SESSION_HANDOVER.md` on `hotfix/issue-266-typescript-fixes`
+- Resolved merge conflict (kept latest handover content)
+- **PR #281 merged to master**: QueryCache event loop fix, PM2 config, complete crossOrigin fixes
+- Switched VPS and local to clean `master` at `5c7a696`
 
-**Running Process:**
-```bash
-Next.js 15.5.7
-PORT: 3001
-Started: Direct npm start (not PM2)
-Status: Running but experiencing progressive slowdown
-```
+### 2. VPS Production Deployment Fixed
+- VPS was on detached HEAD (`9338adc`) — now on `master`
+- PM2 running correctly: `online`, restart count: 0, ~197MB memory
+- All project pages confirmed loading correctly
 
-**System Resources:**
-```bash
-Total Memory: 964Mi
-Available Memory: 173Mi
-Swap: 2.3Gi (262Mi used)
-Next.js Memory: ~65mb (not memory exhaustion)
-```
+### 3. Two Production Issues Diagnosed & Resolved
 
-**PM2 Status:** Not currently running (testing with direct npm start)
+**Issue A — Browser cache mismatch (immediate fix)**
+- Symptom: `Failed to find Server Action "x"` errors in PM2 logs
+- Cause: Browser had stale JS chunks from old build, server action IDs changed
+- Fix: Hard refresh (Ctrl+Shift+R) in browser — no code change needed
 
----
+**Issue B — Project pages hanging on cold start (workaround found)**
+- Symptom: Only "embracing-light..." project loaded; all others hung indefinitely
+- Root cause: SSR page calls `getProject(slug)` which makes an HTTP fetch back to
+  its own `/api/projects/[slug]` route (self-referencing). On cold start with empty ISR
+  cache, this creates a slow round-trip through nginx for every SSR render.
+- Workaround: `curl` of each API route warmed the Next.js ISR cache → pages now load fast
+- Status: **Working now**, but will recur after PM2 restart or 1-hour ISR TTL expiry
 
-## 🔍 Debugging Steps Completed
-
-### 1. Issue #266 Resolution (COMPLETED ✅)
-- PR #268 merged successfully
-- crossOrigin attributes correctly applied to:
-  - `<img>` elements ✅
-  - `<link rel="preload">` elements ✅
-  - Removed from `<source>` elements (HTML5 compliance) ✅
-- TypeScript errors fixed ✅
-- Production deployed ✅
-
-### 2. Performance Regression Investigation (IN PROGRESS 🔄)
-
-**Tests Performed:**
-
-**A. PM2 Environment Testing**
-- Multiple PM2 configurations tried (ecosystem.config.js, memory limits, node args)
-- Result: Same issue persists
-- Error logs: No crashes, just "sh: next: not found" (environment issue, resolved)
-- Restart count: 0-1 (not crashing repeatedly)
-
-**B. Direct npm start Testing**
-- Bypassed PM2 completely
-- Result: **Same progressive slowdown occurs**
-- Conclusion: Not a PM2-specific issue
-
-**C. Memory Analysis**
-- Available memory: 173Mi (adequate)
-- Next.js process: 65mb (reasonable)
-- No memory exhaustion detected
-- Conclusion: Not a memory issue
-
-**D. Git Bisect (CRITICAL)**
-- Reverted to commit 9338adc (before PR #267)
-- Deleted node_modules, .next
-- Fresh npm ci && npm run build
-- Started with direct npm start
-- Result: **SAME ISSUE PERSISTS**
-- **CONCLUSION: Our Issue #266 code DID NOT cause this problem**
-
-**E. Browser Diagnostics**
-- Network tab: Shows NS_ERROR_TIMING on 3rd+ request
-- Console: Font preload warnings (harmless)
-- No specific requests shown as "pending" (connection dies)
-- Pattern: First request works, subsequent requests progressively slower
-
-**F. Server-Side Diagnostics**
-- PM2 logs during failures: No output (request never reaches Next.js)
-- Next.js starts successfully: "Ready in 807ms - 1896ms"
-- No error logs during slowdown
-- Process remains alive (not crashing)
+### 4. ecosystem.config.js Bug Fixed (uncommitted — included in this handoff commit)
+- Removed `wait_ready: true` — Next.js never emits `process.send('ready')`, so PM2
+  would wait forever / behave unpredictably with this setting
+- Changed `shutdown_with_message: false` (no-op for Next.js)
 
 ---
 
-## 💡 Leading Hypotheses
+## 🚨 Outstanding Architectural Issue (Needs GitHub Issue)
 
-### Hypothesis 1: Next.js 15.5.7 SSR Bug ⭐ MOST LIKELY
-**Evidence:**
-- Issue persists across different commits
-- Progressive degradation pattern (works once, fails after)
-- SSR-specific (static assets load fine)
-- Next.js 15.5.7 is recent version (might have regression)
+**File**: `src/app/project/[slug]/hooks/use-project-data.ts` (line 10–11)
 
-**Next Steps:**
-- Check Next.js 15.5.7 release notes for known SSR issues
-- Test downgrading to Next.js 15.5.4 or 15.4.x
-- Check if experimental features in next.config.ts are causing issues
+```ts
+const baseUrl = process.env.NEXT_PUBLIC_URL || 'http://localhost:3000'
+const response = await fetch(`${baseUrl}/api/projects/${slug}`, {
+  next: { revalidate: 3600 },
+})
+```
 
-### Hypothesis 2: Nginx/Reverse Proxy Timeout
-**Evidence:**
-- Browser shows connection timeout (NS_ERROR_TIMING)
-- Request never reaches Next.js logs
-- Could be nginx timing out connections
+**Problem**: `getProject()` is called server-side (SSR) from `page.tsx` for structured data.
+It makes an HTTP request back to its own API route over the network. This means:
 
-**Next Steps:**
-- Check nginx configuration at /etc/nginx/sites-available/
-- Verify proxy_timeout settings
-- Check nginx error logs: /var/log/nginx/error.log
+1. Every cold-start SSR request goes: Browser → nginx → Next.js SSR → nginx → Next.js API → Sanity
+2. If `NEXT_PUBLIC_URL` is not set, fallback is `http://localhost:3000` (wrong port — app on 3001)
+3. ISR cache (`revalidate: 3600`) masks the issue when warm, but cold starts always hang
 
-### Hypothesis 3: Sanity CMS API Rate Limiting
-**Evidence:**
-- Only affects project pages (which fetch from Sanity)
-- Progressive degradation matches rate limit behavior
-- One project ("Embracing Light...") loads fast, others slow
+**Correct fix**: `getProject()` when called server-side should import and call Sanity directly
+(same as the API route does) instead of making a self-referencing HTTP call.
 
-**Next Steps:**
-- Check Sanity dashboard for rate limit warnings
-- Monitor Sanity API response times during failures
-- Test with cached/static data
-
-### Hypothesis 4: Resource Leak in Next.js App Code
-**Evidence:**
-- Progressive degradation (not immediate)
-- Works initially, degrades over time
-- Affects all recent commits
-
-**Next Steps:**
-- Review app code for unclosed connections
-- Check for memory leaks in components
-- Profile Next.js with --inspect flag
+**Impact**: After every PM2 restart the first visit to each project page will be slow/hanging
+until the ISR cache is re-warmed.
 
 ---
 
-## 🛠️ Recommended Debugging Approach for Next Session
+## 🎯 Current Project State
 
-### Phase 1: Eliminate External Factors (30 min)
+**Tests**: Unknown (not run this session — no code changes to app logic)
+**Branch**: `master` ✅ clean (after this handoff commit)
+**CI/CD**: Not checked this session
+**VPS**: ✅ Running, PM2 online, all projects loading
+**ISR cache**: Warm (primed manually via curl) — expires in ~1 hour
 
-**1. Check Nginx Configuration**
-```bash
-# On VPS
-sudo nginx -t
-sudo cat /etc/nginx/sites-available/idaromme.dk
-sudo tail -100 /var/log/nginx/error.log
-```
-
-**2. Test Sanity API Directly**
-```bash
-# Check if Sanity API is slow from VPS
-time curl -s "https://2y05n6hf.apicdn.sanity.io/v2021-10-21/data/query/production?query=*[_type==%22design%22]"
-```
-
-**3. Check for Next.js Known Issues**
-- Search: "Next.js 15.5.7 SSR timeout"
-- Check: https://github.com/vercel/next.js/issues?q=is%3Aissue+15.5.7+SSR
-
-### Phase 2: Next.js Version Testing (45 min)
-
-**1. Downgrade to Next.js 15.5.4**
-```bash
-cd /var/www/idaromme.dk
-git checkout master
-npm install next@15.5.4
-npm run build
-PORT=3001 npm start
-# Test: Load 4-5 projects in a row
-```
-
-**2. If that works, downgrade to Next.js 15.4.x**
-```bash
-npm install next@15.4.3
-npm run build
-PORT=3001 npm start
-```
-
-### Phase 3: App Code Review (30 min)
-
-**Files to investigate:**
-```
-src/app/project/[slug]/page.tsx - Project page SSR
-src/lib/sanity/client.ts - Sanity client configuration
-middleware.ts - Request middleware
-```
-
-**Look for:**
-- Unclosed database/API connections
-- Missing error boundaries
-- Infinite loops in getStaticProps/generateMetadata
-- Resource-intensive operations
-
-### Phase 4: Enable Debug Logging (15 min)
-
-**Start Next.js with debug flags:**
-```bash
-NODE_OPTIONS='--trace-warnings --trace-deprecation' PORT=3001 npm start
-```
-
-**Add logging to project page:**
-```typescript
-// In src/app/project/[slug]/page.tsx
-export default async function Page({ params }) {
-  console.log('[SSR START]', new Date(), params.slug)
-  // ... existing code
-  console.log('[SSR END]', new Date(), params.slug)
-}
-```
+### Agent Validation Status
+- [ ] architecture-designer: Not run — needed for self-referencing HTTP fix
+- [ ] security-validator: Not run
+- [ ] code-quality-analyzer: Not run
+- [ ] test-automation-qa: Not run
+- [ ] performance-optimizer: Not run
+- [ ] documentation-knowledge-manager: Not run
 
 ---
 
-## 📋 VPS Quick Reference
+## 🚀 Next Session Priorities
 
-**SSH Access:**
-```bash
-ssh max@idaromme.dk
-cd /var/www/idaromme.dk
-```
+**Immediate (before ISR cache expires on VPS):**
 
-**Node.js Setup:**
-```bash
-source ~/.nvm/nvm.sh
-nvm use 22
-node --version  # Should show v22.16.0
-```
+1. **Open GitHub issue** for the self-referencing HTTP architectural bug in `use-project-data.ts`
+2. **Fix**: Refactor `getProject()` to call Sanity directly when running server-side,
+   eliminating the HTTP round-trip and port-mismatch risk
+3. **Deploy fix** to VPS so cold starts are reliable without manual cache warming
 
-**Useful Commands:**
-```bash
-# Check what's running on port 3001
-netstat -tlnp | grep 3001
-
-# Kill all Node processes
-pkill -f next
-
-# Check memory
-free -h
-
-# Monitor in real-time
-htop  # (if installed)
-
-# Check nginx
-sudo systemctl status nginx
-sudo nginx -t
-
-# PM2 commands
-pm2 list
-pm2 logs idaromme-website --lines 50
-pm2 delete idaromme-website
-```
-
-**Current Process:**
-- Next.js running directly (not PM2)
-- PORT 3001
-- Press Ctrl+C to stop
-
----
-
-## 📚 Key Files
-
-**Configuration:**
-- `next.config.ts` - Next.js config (experimental features enabled)
-- `ecosystem.config.js` - PM2 config (if using PM2)
-- `/etc/nginx/sites-available/idaromme.dk` - Nginx config
-
-**App Code:**
-- `src/app/project/[slug]/page.tsx` - Project page SSR
-- `src/lib/sanity/client.ts` - Sanity API client
-- `middleware.ts` - Request middleware
-
-**Logs:**
-- `/home/max/.pm2/logs/idaromme-website-*.log` - PM2 logs
-- `/var/log/nginx/error.log` - Nginx errors
-- `/var/log/nginx/access.log` - Nginx access
-
----
-
-## 🎯 Success Criteria
-
-**Issue resolved when:**
-- ✅ Can load 10+ different project pages consecutively
-- ✅ Each page loads in < 5 seconds
-- ✅ No timeouts or NS_ERROR_TIMING errors
-- ✅ Performance remains consistent over time
-- ✅ Works with both PM2 and direct npm start
+**Then:**
+- Run full test suite to confirm nothing broken by recent merges
+- Consider if any new feature/bugfix work is queued
 
 ---
 
 ## 📝 Startup Prompt for Next Session
 
 ```
-Read CLAUDE.md to understand our workflow, then debug critical production performance issue.
+Read CLAUDE.md to understand our workflow, then fix a known architectural bug.
 
-**CRITICAL**: Project pages experience progressive timeout (1st works, 2nd slow, 3rd+ timeout).
+**Issue to open & fix**: `src/app/project/[slug]/hooks/use-project-data.ts`
+`getProject()` makes a self-referencing HTTP call back to the app's own API route
+during SSR. This causes project pages to hang on cold start (after PM2 restart or
+1-hour ISR cache expiry). Fix: call Sanity directly from server-side instead of
+HTTP-fetching the API route.
 
-**Context**: Issue #266 (crossOrigin) is COMPLETE and NOT the cause. This is a separate issue that exists even on old commits (9338adc). Next.js 15.5.7 SSR appears to be hanging after 1-2 requests.
+**VPS state**: Running fine RIGHT NOW (ISR cache warm), but will break on next restart.
+**Branch**: `master`, clean, commit `5c7a696`
+**Reference**: SESSION_HANDOVER.md section "Outstanding Architectural Issue"
 
-**Current VPS state**:
-- Detached HEAD at 9338adc (testing old code)
-- Next.js running directly on PORT 3001 (not PM2)
-- Pattern: NS_ERROR_TIMING in browser, no logs in Next.js
-
-**Immediate priorities**:
-1. Check nginx timeout configuration
-2. Test Next.js 15.5.4 (downgrade from 15.5.7)
-3. Review Sanity API rate limiting
-4. Enable debug logging in app code
-
-**Reference**: SESSION_HANDOVER.md sections "Leading Hypotheses" and "Recommended Debugging Approach"
-
-**Expected scope**: Identify root cause (Next.js bug, nginx config, or app code issue) and implement fix to restore normal performance.
+**Expected scope**: Open GitHub issue, implement fix with TDD, PR, deploy to VPS.
 ```
 
 ---
 
-**Session paused**: 2026-01-18T18:30:00Z
-**Status**: Performance regression identified, NOT related to Issue #266, debugging in progress
-**Next session owner**: Continue debugging with fresh perspective
+**Session ended**: 2026-02-28
+**Status**: VPS stable, architectural bug documented, fix pending

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -37,14 +37,12 @@ module.exports = {
       // Process management
       kill_timeout: 5000, // Wait 5s for graceful shutdown
       listen_timeout: 10000, // Wait 10s for app to be ready
-      shutdown_with_message: true,
+      shutdown_with_message: false,
 
       // Health monitoring
       watch: false, // Don't watch files in production
       ignore_watch: ['node_modules', '.next', 'logs'],
 
-      // Graceful shutdown
-      wait_ready: true, // Wait for app to signal ready
 
       // Environment-specific settings
       env_production: {


### PR DESCRIPTION
## Summary

- Updates SESSION_HANDOVER.md with full production debugging outcomes from this session
- Fixes `ecosystem.config.js`: removes `wait_ready: true` (Next.js never emits the ready signal) and sets `shutdown_with_message: false`
- Documents the self-referencing HTTP call architectural bug in `use-project-data.ts` for the next session to fix

## What happened this session

- Merged PR #281 (remaining hotfix work) to master
- Deployed to VPS, diagnosed two production issues:
  1. Browser cache mismatch after new build — fixed with hard refresh
  2. Project pages hanging on cold start — traced to SSR making self-referencing HTTP calls back to its own API routes, masked by ISR cache
- VPS is stable and running, all projects loading

## Test plan

- [ ] No app logic changes — just config and docs