### PR TITLE
fix: replace self-referencing HTTP call with direct Sanity queries (#284)

### DIFF
--- a/src/app/project/[slug]/hooks/__tests__/use-project-data.test.ts
+++ b/src/app/project/[slug]/hooks/__tests__/use-project-data.test.ts
@@ -1,0 +1,158 @@
+// ABOUTME: Tests for use-project-data — verifies direct Sanity queries instead of HTTP self-calls
+
+import { getProject, getProjectWithNavigation } from '../use-project-data'
+
+// Mock Sanity modules used by the functions under test
+jest.mock('@/sanity/queries', () => ({
+  queries: {
+    getProjectBySlug: 'mock-getProjectBySlug-query',
+    getProjectNavigation: 'mock-getProjectNavigation-query',
+    getAllSlugs: 'mock-getAllSlugs-query',
+  },
+}))
+
+const mockResilientFetch = jest.fn()
+jest.mock('@/sanity/dataFetcher', () => ({
+  resilientFetch: (...args: unknown[]) => mockResilientFetch(...args),
+}))
+
+const mockProject = {
+  _id: 'abc123',
+  title: 'Test Textile',
+  slug: { current: 'test-textile' },
+  year: 2024,
+  featured: false,
+  order: 1,
+  _createdAt: '2024-01-01T00:00:00Z',
+}
+
+const mockNavigation = {
+  current: { _id: 'abc123', title: 'Test Textile', slug: { current: 'test-textile' }, order: 1 },
+  previous: { _id: 'prev1', title: 'Previous Work', slug: { current: 'previous-work' } },
+  next: { _id: 'next1', title: 'Next Work', slug: { current: 'next-work' } },
+}
+
+beforeEach(() => {
+  mockResilientFetch.mockReset()
+  // Define global.fetch as a mock (jsdom doesn't provide it natively)
+  global.fetch = jest.fn().mockImplementation(() => {
+    throw new Error('fetch should not be called — use resilientFetch directly')
+  }) as jest.Mock
+})
+
+afterEach(() => {
+  delete (global as Record<string, unknown>).fetch
+})
+
+describe('getProject', () => {
+  it('calls resilientFetch with getProjectBySlug query and correct params', async () => {
+    mockResilientFetch.mockResolvedValueOnce(mockProject)
+
+    const result = await getProject('test-textile')
+
+    expect(mockResilientFetch).toHaveBeenCalledWith(
+      'mock-getProjectBySlug-query',
+      { slug: 'test-textile' },
+      expect.objectContaining({ cache: true })
+    )
+    expect(result).toEqual(mockProject)
+  })
+
+  it('does NOT call global fetch (no HTTP self-reference)', async () => {
+    mockResilientFetch.mockResolvedValueOnce(mockProject)
+
+    await getProject('test-textile')
+
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns null when resilientFetch returns null (project not found)', async () => {
+    mockResilientFetch.mockResolvedValueOnce(null)
+
+    const result = await getProject('nonexistent')
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null on unexpected error', async () => {
+    mockResilientFetch.mockRejectedValueOnce(new Error('Sanity unreachable'))
+
+    const result = await getProject('test-textile')
+
+    expect(result).toBeNull()
+  })
+})
+
+describe('getProjectWithNavigation', () => {
+  it('calls resilientFetch for both project and navigation in parallel', async () => {
+    mockResilientFetch
+      .mockResolvedValueOnce(mockProject)
+      .mockResolvedValueOnce(mockNavigation)
+
+    await getProjectWithNavigation('test-textile')
+
+    expect(mockResilientFetch).toHaveBeenCalledTimes(2)
+    expect(mockResilientFetch).toHaveBeenCalledWith(
+      'mock-getProjectBySlug-query',
+      { slug: 'test-textile' },
+      expect.objectContaining({ cache: true })
+    )
+    expect(mockResilientFetch).toHaveBeenCalledWith(
+      'mock-getProjectNavigation-query',
+      { slug: 'test-textile' },
+      expect.objectContaining({ cache: true })
+    )
+  })
+
+  it('does NOT call global fetch (no HTTP self-reference)', async () => {
+    mockResilientFetch
+      .mockResolvedValueOnce(mockProject)
+      .mockResolvedValueOnce(mockNavigation)
+
+    await getProjectWithNavigation('test-textile')
+
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns project with extracted next and previous navigation slugs', async () => {
+    mockResilientFetch
+      .mockResolvedValueOnce(mockProject)
+      .mockResolvedValueOnce(mockNavigation)
+
+    const result = await getProjectWithNavigation('test-textile')
+
+    expect(result.project).toEqual(mockProject)
+    expect(result.nextProject).toEqual({ slug: 'next-work', title: 'Next Work' })
+    expect(result.previousProject).toEqual({ slug: 'previous-work', title: 'Previous Work' })
+  })
+
+  it('returns project without navigation when navigation is null', async () => {
+    mockResilientFetch
+      .mockResolvedValueOnce(mockProject)
+      .mockResolvedValueOnce(null)
+
+    const result = await getProjectWithNavigation('test-textile')
+
+    expect(result.project).toEqual(mockProject)
+    expect(result.nextProject).toBeUndefined()
+    expect(result.previousProject).toBeUndefined()
+  })
+
+  it('returns { project: null } when project not found', async () => {
+    mockResilientFetch
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+
+    const result = await getProjectWithNavigation('nonexistent')
+
+    expect(result).toEqual({ project: null })
+  })
+
+  it('returns { project: null } on unexpected error', async () => {
+    mockResilientFetch.mockRejectedValueOnce(new Error('Sanity unreachable'))
+
+    const result = await getProjectWithNavigation('test-textile')
+
+    expect(result).toEqual({ project: null })
+  })
+})

--- a/src/app/project/[slug]/hooks/use-project-data.ts
+++ b/src/app/project/[slug]/hooks/use-project-data.ts
@@ -1,35 +1,29 @@
+// ABOUTME: Server-side data fetching for project pages — queries Sanity directly (no HTTP round-trip)
+// Replaces the previous self-referencing HTTP call that caused cold-start hangs after PM2 restart
+
 import { TextileDesign } from '@/types/textile'
 
 export async function getProject(slug: string): Promise<TextileDesign | null> {
   try {
     if (process.env.NODE_ENV === 'development') {
-      console.log(`🔍 Fetching project from API: ${slug}`)
+      console.log(`🔍 Fetching project from Sanity: ${slug}`)
     }
 
-    // Fetch from our API route instead of direct Sanity queries
-    const baseUrl = process.env.NEXT_PUBLIC_URL || 'http://localhost:3000'
-    const response = await fetch(`${baseUrl}/api/projects/${slug}`, {
-      // Enable ISR caching
-      next: { revalidate: 3600 }, // 1 hour
-    })
+    const [{ queries }, { resilientFetch }] = await Promise.all([
+      import('@/sanity/queries'),
+      import('@/sanity/dataFetcher'),
+    ])
 
-    if (!response.ok) {
-      if (response.status === 404) {
-        if (process.env.NODE_ENV === 'development') {
-          console.warn(`⚠️ Project not found: ${slug}`)
-        }
-        return null
+    const project = await resilientFetch<TextileDesign>(
+      queries.getProjectBySlug,
+      { slug },
+      {
+        retries: 3,
+        timeout: 15000,
+        cache: true,
+        cacheTTL: 600000,
       }
-      if (process.env.NODE_ENV === 'development') {
-        console.warn(
-          `⚠️ API responded with status: ${response.status} for ${slug}`
-        )
-      }
-      return null
-    }
-
-    const data = await response.json()
-    const project = data.project
+    )
 
     if (process.env.NODE_ENV === 'development') {
       if (project) {
@@ -41,7 +35,7 @@ export async function getProject(slug: string): Promise<TextileDesign | null> {
 
     return project
   } catch (error) {
-    console.error(`❌ Failed to fetch project ${slug} from API:`, error)
+    console.error(`❌ Failed to fetch project ${slug}:`, error)
     return null
   }
 }
@@ -100,54 +94,82 @@ export async function getProjectWithNavigation(slug: string): Promise<{
 }> {
   try {
     if (process.env.NODE_ENV === 'development') {
-      console.log(`🔍 Fetching project with navigation from API: ${slug}`)
+      console.log(`🔍 Fetching project with navigation from Sanity: ${slug}`)
     }
 
-    // Fetch from our API route instead of direct Sanity queries
-    const baseUrl = process.env.NEXT_PUBLIC_URL || 'http://localhost:3000'
-    const response = await fetch(`${baseUrl}/api/projects/${slug}`, {
-      // Enable ISR caching
-      next: { revalidate: 3600 }, // 1 hour
-    })
+    const [{ queries }, { resilientFetch }] = await Promise.all([
+      import('@/sanity/queries'),
+      import('@/sanity/dataFetcher'),
+    ])
 
-    if (!response.ok) {
-      if (response.status === 404) {
-        if (process.env.NODE_ENV === 'development') {
-          console.warn(`⚠️ Project not found: ${slug}`)
+    const [project, navigation] = await Promise.all([
+      resilientFetch<TextileDesign>(
+        queries.getProjectBySlug,
+        { slug },
+        {
+          retries: 3,
+          timeout: 15000,
+          cache: true,
+          cacheTTL: 600000,
         }
-        return { project: null }
-      }
-      if (process.env.NODE_ENV === 'development') {
-        console.warn(
-          `⚠️ API responded with status: ${response.status} for ${slug}`
-        )
-      }
-      return { project: null }
-    }
+      ),
+      resilientFetch<{
+        current: {
+          _id: string
+          title: string
+          slug: { current: string }
+          order: number
+        } | null
+        previous: {
+          _id: string
+          title: string
+          slug: { current: string }
+        } | null
+        next: { _id: string; title: string; slug: { current: string } } | null
+      }>(
+        queries.getProjectNavigation,
+        { slug },
+        {
+          retries: 2,
+          timeout: 10000,
+          cache: true,
+          cacheTTL: 300000,
+        }
+      ),
+    ])
 
-    const data = await response.json()
-
-    if (!data.project) {
+    if (!project) {
       if (process.env.NODE_ENV === 'development') {
         console.warn(`⚠️ Project not found: ${slug}`)
       }
       return { project: null }
     }
 
+    const nextProject = navigation?.next
+      ? { slug: navigation.next.slug.current, title: navigation.next.title }
+      : undefined
+
+    const previousProject = navigation?.previous
+      ? {
+          slug: navigation.previous.slug.current,
+          title: navigation.previous.title,
+        }
+      : undefined
+
     if (process.env.NODE_ENV === 'development') {
       console.log(
-        `✅ Navigation data from API: previous=${data.previousProject?.title}, next=${data.nextProject?.title}`
+        `✅ Navigation data from Sanity: previous=${previousProject?.title}, next=${nextProject?.title}`
       )
     }
 
     return {
-      project: data.project,
-      nextProject: data.nextProject,
-      previousProject: data.previousProject,
+      project,
+      nextProject,
+      previousProject,
     }
   } catch (error) {
     console.error(
-      `❌ Failed to fetch project with navigation ${slug} from API:`,
+      `❌ Failed to fetch project with navigation ${slug}:`,
       error
     )
     return { project: null }


### PR DESCRIPTION
## Summary

- `getProject()` and `getProjectWithNavigation()` in `use-project-data.ts` were making HTTP fetch calls back to the app's own `/api/projects/[slug]` route during SSR
- This caused project pages to hang on cold start (after PM2 restart or 1-hour ISR cache expiry)
- Replaced with direct `resilientFetch` calls to Sanity, matching the pattern already used in `getAllProjectSlugs()` and the API route handler

## Root Cause

```ts
// BEFORE (broken): double network hop through nginx on every SSR render
const baseUrl = process.env.NEXT_PUBLIC_URL || 'http://localhost:3000'
const response = await fetch(`${baseUrl}/api/projects/${slug}`, {
  next: { revalidate: 3600 },
})
```

```ts
// AFTER (fixed): direct Sanity query, same pattern as the API route
const project = await resilientFetch<TextileDesign>(
  queries.getProjectBySlug,
  { slug },
  { retries: 3, timeout: 15000, cache: true, cacheTTL: 600000 }
)
```

## Test plan

- [x] TDD: wrote failing tests first (RED), then implemented fix (GREEN)
- [x] 10 new unit tests covering: direct Sanity calls, no-HTTP-self-call, null handling, error handling, navigation extraction
- [x] Full test suite: 959 passing, 0 new failures
- [x] Pre-commit hooks all pass

Fixes #284