### PR TITLE
fix: add minimumCacheTTL 1yr to Next.js image config (Fixes #308)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -24,6 +24,7 @@ const nextConfig = {
       },
     ],
     formats: ['image/avif', 'image/webp'], // AVIF first for better compression, WebP fallback
+    minimumCacheTTL: 31536000, // Cache optimized images for 1 year (fixes Issue #308 cold-start slowness)
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
     dangerouslyAllowSVG: true,


### PR DESCRIPTION
## Summary

- Adds `minimumCacheTTL: 31536000` to the `images` block in `next.config.ts`
- Fixes first-visit slow image loading on idaromme.dk (Issue #308)

**Root cause**: Next.js defaults `minimumCacheTTL` to 60 seconds. On a low-traffic portfolio site, the `/_next/image` cache was effectively always cold — every request triggered a full re-encode cycle (download from Sanity CDN → AVIF encode → cache). With a 60s TTL, even returning visitors within minutes would re-trigger encoding.

**Fix**: Cache optimised images for 1 year. AVIF encoding now happens once per unique image+size combination, then served from disk for all subsequent requests.

**Not affected**: Lockdown Mode images use `LockdownImage` which bypasses `/_next/image` entirely.

## Test plan

- [x] All 982 unit/integration tests pass (1 pre-existing skipped suite unrelated)
- [x] Pre-commit hooks pass
- [ ] Deploy to production and verify first-visit load time improves