### PR TITLE
fix: bump serialize-javascript to 7.0.3 via npm overrides (Fixes #311)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22469,16 +22469,6 @@
         "performance-now": "^2.1.0"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -25453,13 +25443,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
+      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/server-only": {

--- a/package.json
+++ b/package.json
@@ -76,5 +76,8 @@
     "**/glob": "^11.0.2",
     "**/inflight": "^1.0.6"
   },
+  "overrides": {
+    "serialize-javascript": ">=7.0.3"
+  },
   "engineStrict": true
 }


### PR DESCRIPTION
## Summary

- Adds `"overrides": { "serialize-javascript": ">=7.0.3" }` to `package.json`
- Forces the resolved version of `serialize-javascript` to 7.0.3 across the entire dependency tree, bypassing `terser-webpack-plugin`'s `^6.0.2` pin
- Refreshed `package-lock.json` causes GitHub to rescan and auto-dismiss ~15 stale Dependabot alerts whose packages are already installed at patched versions

## Security context

**Dependabot alert #44 (high):** `serialize-javascript < 7.0.3` is vulnerable to RCE via `RegExp.flags` and `Date.prototype.toISOString()`.

Dependency path: `webpack → terser-webpack-plugin@5.3.16 → serialize-javascript@6.0.2`

## Test plan

- [x] 982 unit/integration tests passing (`npm run test:ci`)
- [x] Pre-commit hooks satisfied
- [x] `serialize-javascript` confirmed at 7.0.3 post-install