### PR TITLE
fix: bump glob nested in @architect chain to ^10.5.0 via npm overrides (Fixes #314)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -209,9 +209,9 @@
       }
     },
     "node_modules/@architect/hydrate/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
       "peer": true,
@@ -345,24 +345,22 @@
       }
     },
     "node_modules/@architect/utils/node_modules/glob": {
-      "version": "10.3.16",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.16.tgz",
-      "integrity": "sha512-JDKXl1DiuuHJ6fVS2FXjownaavciiHNUU4mOvV/B793RLh05vZL1rcPnCSaOgv1hDT6RDlY7AB7ZUvFYAtPgAw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
       "peer": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.1",
-        "minipass": "^7.0.4",
-        "path-scurry": "^1.11.0"
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,13 @@
     "**/inflight": "^1.0.6"
   },
   "overrides": {
-    "serialize-javascript": ">=7.0.3"
+    "serialize-javascript": ">=7.0.3",
+    "@architect/hydrate": {
+      "glob": "^10.5.0"
+    },
+    "@architect/utils": {
+      "glob": "^10.5.0"
+    }
   },
   "engineStrict": true
 }


### PR DESCRIPTION
## Summary

- **CVE-2025-64756** / GHSA-5j98-mcp5-4vw2: glob CLI command injection via `-c/--cmd` with `shell:true` (high, CVSS 7.5)
- Vulnerable chain: `@sanity/cli → @sanity/runtime-cli → @architect/hydrate → glob@10.4.5` and `@architect/utils → glob@10.3.16` (both in vulnerable range `>=10.2.0, <10.5.0`)
- Added nested npm `overrides` to force both `@architect/hydrate` and `@architect/utils` to use `glob@^10.5.0`
- Same pattern as #312 (serialize-javascript override)

## Test plan

- [x] `npm ls glob` — all 10.x instances now at `10.5.0`; no `10.4.5` or `10.3.16` remaining
- [x] `npm run test:ci` — 982 tests pass, 0 failures
- [x] Pre-commit hooks pass

Closes #314