### PR TITLE
fix: navigate to /projects on Escape instead of router.back()

### DIFF
--- a/src/components/desktop/Project/DesktopImageCarousel.tsx
+++ b/src/components/desktop/Project/DesktopImageCarousel.tsx
@@ -188,7 +188,7 @@ export function DesktopImageCarousel({
     }
     UmamiEvents.backToGallery()
     scrollManager.triggerNavigationStart()
-    router.back()
+    router.push('/projects')
   }, [router])
 
   // Keyboard navigation handlers for the hook


### PR DESCRIPTION
## Summary
- Pressing Escape on a project page opened directly (no browser history) caused a blank page
- `router.back()` has no history to go back to in that case
- Changed to `router.push('/projects')` which always navigates correctly to the gallery

## Test plan
- [ ] Open a project page directly via URL (e.g. paste into new tab)
- [ ] Press Escape — should navigate to the projects gallery
- [ ] Open a project from the gallery, press Escape — should also go to the gallery