### PR TITLE
docs: session handoff 2026-03-08 — PR #335 tar security patch merged

### DIFF
--- a/SESSION_HANDOVER.md
+++ b/SESSION_HANDOVER.md
@@ -1,68 +1,50 @@
-# Session Handoff: Issue #332 — MERGED to master
+# Session Handoff: PR #335 — Dependabot tar security patch merged
 
 **Date**: 2026-03-08
-**Issue**: #332 — refactor: codebase cleanup — reduce duplication, improve test coverage, remove dead code
-**PR**: #334 — merged to master (squash commit `49ffe30`)
-**Branch**: feat/issue-332-refactor (merged, can be deleted)
+**Issue**: N/A (Dependabot automated security PR)
+**PR**: #335 — merged to master (squash commit `0b9f546`)
+**Branch**: `dependabot/npm_and_yarn/tar-7.5.10` (merged, deleted by GitHub)
 
 ---
 
 ## ✅ Completed This Session
 
-### What was done to get to merge
-
-Two CI failures were found and fixed after the previous handoff pushed the PR:
-
-| Commit | Work |
-|--------|------|
-| `6cb166d` | Force deterministic Sanity env vars in jest.config.ts — CI's real project ID (masked as `***`) was overriding the `??=` fallbacks, breaking URL-matching assertions in image-helpers tests. Changed to unconditional `=`. |
-| `a0dc114` | Fix E2E test `User sees validation error for invalid email` — submit button correctly disabled for invalid form; test was trying to click it. Updated to assert `toBeDisabled()` and read `validationMessage` via DOM API directly. |
-| `b13f4de` | Fix E2E test `Validation errors are announced to screen readers` — same root cause. |
-
-### Full PR scope (all 11 commits squashed to master)
-
-- Phase 1: Added 177 missing unit tests
-- Phase 2: Extracted shared components (`useContactForm`, `BaseFormField`, `ProjectDetails`)
-- Fixed `FormValidator` re-instantiation bug (useRef stabilisation)
-- Fixed MobileButton loading text alignment
-- Added ABOUTME header to DesktopContactForm
-- Fixed jest.config.ts env var isolation
-- Fixed 2 E2E tests to reflect correct disabled-button behaviour
+- Reviewed Dependabot PR #335: `tar` 7.5.9 → 7.5.10 (path traversal vulnerability fix)
+- All CI green before merge (Jest, Lighthouse desktop/mobile, Bundle Size)
+- Merged via `gh pr merge 335 --squash --auto`
 
 ---
 
 ## 🎯 Current Project State
 
-**Tests**: ✅ All passing — Jest + Playwright (Desktop/Mobile/Safari) + Lighthouse + Bundle Size
-**Branch**: `master` at `49ffe30` — clean
-**Issue #332**: ✅ Closed (auto-closed by PR merge at 2026-03-08T07:29:10Z)
-**PR #334**: ✅ Merged
-**Production**: idaromme.dk — stable (no deploy changes in this PR)
+**Tests**: ✅ All passing
+**Branch**: `master` at `0b9f546` — clean
+**PR #335**: ✅ Merged
+**Production**: idaromme.dk — stable
 
 ---
 
 ## 🚀 Next Session Priorities
 
-### Optional follow-up (separate issues if desired)
-
-1. Add `loadingText` prop to `DesktopButton` for symmetry with `MobileButton`
-2. Add direct unit tests for `useContactForm` hook and `BaseFormField`/`ProjectDetails` desktop paths
-3. Any further deduplication (e.g., `MobileProjectGallery` / `DesktopProjectGallery`)
-4. Dependabot PR #335 for `tar` vulnerability (1 high, 1 moderate on default branch — worth reviewing)
+1. **Issue #262** — Add comprehensive regression tests for Issue #259 Lockdown Mode fix (open since Dec 2025, test branch exists: `test/issue-259-lockdown-mode-regression-tests`)
+2. Optional refactors from Issue #332 follow-up:
+   - Add `loadingText` prop to `DesktopButton` (symmetry with `MobileButton`)
+   - Direct unit tests for `useContactForm` hook and `BaseFormField`/`ProjectDetails` desktop paths
+   - Further deduplication (`MobileProjectGallery` / `DesktopProjectGallery`)
 
 ---
 
 ## 📝 Startup Prompt for Next Session
 
 ```
-Read CLAUDE.md to understand our workflow, then pick up after Issue #332 merge.
+Read CLAUDE.md to understand our workflow, then pick up after PR #335 merge.
 
-**Immediate priority**: Review open issues for next task, or address Dependabot PR #335 (tar vulnerability)
-**Context**: Issue #332 fully merged — 11 commits squashed, all CI green, master clean at 49ffe30
+**Immediate priority**: Issue #262 — regression tests for Lockdown Mode fix (branch already exists: test/issue-259-lockdown-mode-regression-tests)
+**Context**: Security patch (tar path traversal) merged; master clean at 0b9f546; production stable
 **Reference docs**: SESSION_HANDOVER.md
 **Ready state**: master clean, all tests passing, no uncommitted changes
 
-**Expected scope**: New issue triage or Dependabot security PR review/merge
+**Expected scope**: Review Issue #262 scope, implement regression tests on existing branch, get CI green, merge
 ```
 
 ---
@@ -70,9 +52,5 @@ Read CLAUDE.md to understand our workflow, then pick up after Issue #332 merge.
 ## 📚 Key Reference Documents
 
 - `SESSION_HANDOVER.md` — this file
-- Issue #332: https://github.com/maxrantil/textile-showcase/issues/332 (closed)
-- PR #334: https://github.com/maxrantil/textile-showcase/pull/334 (merged)
-- Shared components added:
-  - `src/hooks/shared/useContactForm.ts`
-  - `src/components/shared/Forms/BaseFormField.tsx`
-  - `src/components/shared/Project/ProjectDetails.tsx`
+- Issue #262: https://github.com/maxrantil/textile-showcase/issues/262
+- PR #335: https://github.com/maxrantil/textile-showcase/pull/335 (merged)


### PR DESCRIPTION
## Summary
- Updates SESSION_HANDOVER.md after merging Dependabot PR #335 (tar 7.5.9 → 7.5.10)
- Documents next session priorities (Issue #262 regression tests)
- Generates startup prompt for next session

## Test plan
- [ ] No code changes — docs only