### PR TITLE
perf: remove avif in favour of webp — fixes LCP and Sanity 400 errors

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -26,7 +26,7 @@ const nextConfig = {
         pathname: '/images/**',
       },
     ],
-    formats: ['image/avif', 'image/webp'], // AVIF first for better compression, WebP fallback
+    formats: ['image/webp'], // WebP only - avif encoding too slow on VPS (5+ second LCP overhead)
     minimumCacheTTL: 31536000, // Cache optimized images for 1 year (fixes Issue #308 cold-start slowness)
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -101,22 +101,21 @@ export default async function Home() {
   // Issue #51 Phase 1: Get first design for FirstImage component
   const firstDesign = designs[0]
 
-  // Issue #78/#41: Generate preload URLs for LCP image using helper
-  // Issue #41: Quality reduced from 50 to 40, breakpoint 320w → 480w for mobile
+  // Generate preload URLs for LCP image using helper (webp - avif removed, Sanity 400s on ?fm=avif)
   const imageSource = firstDesign?.image || firstDesign?.images?.[0]?.asset
   const preloadUrl = imageSource
     ? getOptimizedImageUrl(imageSource, {
         width: 640,
         quality: 40,
-        format: 'avif',
+        format: 'webp',
       })
     : null
 
   const preloadSrcSet = imageSource
     ? [
-        `${getOptimizedImageUrl(imageSource, { width: 480, quality: 40, format: 'avif' })} 480w`,
-        `${getOptimizedImageUrl(imageSource, { width: 640, quality: 40, format: 'avif' })} 640w`,
-        `${getOptimizedImageUrl(imageSource, { width: 960, quality: 40, format: 'avif' })} 960w`,
+        `${getOptimizedImageUrl(imageSource, { width: 480, quality: 40, format: 'webp' })} 480w`,
+        `${getOptimizedImageUrl(imageSource, { width: 640, quality: 40, format: 'webp' })} 640w`,
+        `${getOptimizedImageUrl(imageSource, { width: 960, quality: 40, format: 'webp' })} 960w`,
       ].join(', ')
     : null
 
@@ -137,7 +136,7 @@ export default async function Home() {
           href={preloadUrl}
           imageSrcSet={preloadSrcSet || undefined}
           imageSizes="(max-width: 480px) 100vw, (max-width: 768px) 90vw, 640px"
-          type="image/avif"
+          type="image/webp"
           fetchPriority="high"
           crossOrigin="anonymous"
         />

--- a/src/app/project/[slug]/page.tsx
+++ b/src/app/project/[slug]/page.tsx
@@ -42,7 +42,7 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
     ? getOptimizedImageUrl(imageSource, {
         width: 800,
         quality: 80,
-        format: 'avif',
+        format: 'webp',
       })
     : null
 
@@ -58,7 +58,7 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
           rel="preload"
           as="image"
           href={preloadUrl}
-          type="image/avif"
+          type="image/webp"
           fetchPriority="high"
           crossOrigin="anonymous"
         />

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -95,22 +95,21 @@ export default async function ProjectsPage() {
   // Get first design for FirstImage component
   const firstDesign = designs[0]
 
-  // Issue #41: Generate preload URLs for LCP image using helper
-  // Quality reduced from 50 to 40, breakpoint 320w → 480w for mobile
+  // Generate preload URLs for LCP image using helper (webp - avif removed, Sanity 400s on ?fm=avif)
   const imageSource = firstDesign?.image || firstDesign?.images?.[0]?.asset
   const preloadUrl = imageSource
     ? getOptimizedImageUrl(imageSource, {
         width: 640,
         quality: 40,
-        format: 'avif',
+        format: 'webp',
       })
     : null
 
   const preloadSrcSet = imageSource
     ? [
-        `${getOptimizedImageUrl(imageSource, { width: 480, quality: 40, format: 'avif' })} 480w`,
-        `${getOptimizedImageUrl(imageSource, { width: 640, quality: 40, format: 'avif' })} 640w`,
-        `${getOptimizedImageUrl(imageSource, { width: 960, quality: 40, format: 'avif' })} 960w`,
+        `${getOptimizedImageUrl(imageSource, { width: 480, quality: 40, format: 'webp' })} 480w`,
+        `${getOptimizedImageUrl(imageSource, { width: 640, quality: 40, format: 'webp' })} 640w`,
+        `${getOptimizedImageUrl(imageSource, { width: 960, quality: 40, format: 'webp' })} 960w`,
       ].join(', ')
     : null
 
@@ -130,7 +129,7 @@ export default async function ProjectsPage() {
           href={preloadUrl}
           imageSrcSet={preloadSrcSet || undefined}
           imageSizes="(max-width: 480px) 100vw, (max-width: 768px) 90vw, 640px"
-          type="image/avif"
+          type="image/webp"
           fetchPriority="high"
           crossOrigin="anonymous"
         />

--- a/src/components/mobile/Gallery/MobileGalleryItem.tsx
+++ b/src/components/mobile/Gallery/MobileGalleryItem.tsx
@@ -109,8 +109,8 @@ export default function MobileGalleryItem({
               <Image
                 src={imageUrl}
                 alt={alt}
-                width={800}
-                height={600}
+                width={600}
+                height={800}
                 sizes="100vw"
                 priority={isPriority}
                 loading={isPriority ? 'eager' : 'lazy'}

--- a/src/components/server/FirstImage.tsx
+++ b/src/components/server/FirstImage.tsx
@@ -14,16 +14,8 @@ interface FirstImageProps {
  * Critical for performance - enables browser to discover and start loading
  * the LCP image immediately without waiting for React hydration (~6-10s delay)
  *
- * Issue #78 Optimization:
- * - Added <link rel="preload"> in page.tsx head for immediate discovery
- * - Switched from WebP to AVIF (30-40% better compression)
- * - Reduced quality from 60 to 40 (aggressive LCP optimization)
- *
- * Expected impact:
- * - Load Delay: 6.2s → <1s (preload eliminates discovery gap)
- * - Load Time: 3.1s → 1.5-2s (AVIF compression)
- * - Render Delay: 4.7s → 1-1.5s (faster download)
- * - LCP: 14.9s → 2-2.5s (85% improvement)
+ * Uses WebP (avif removed - Sanity CDN returns 400 for ?fm=avif)
+ * Quality 40, sizes 480/640/960w for LCP optimization
  *
  * This component will be hidden after client hydration via CSS
  */
@@ -34,16 +26,7 @@ export function FirstImage({ design }: FirstImageProps) {
     return null
   }
 
-  // Issue #78/#41: Generate AVIF srcset with aggressive quality for LCP optimization
-  // AVIF provides 30-40% better compression than WebP at same quality
-  // Issue #41: Quality reduced from 50 to 40, breakpoint 320w → 480w for mobile
-  const avifSrcSet = `
-    ${getOptimizedImageUrl(imageSource, { width: 480, quality: 40, format: 'avif' })} 480w,
-    ${getOptimizedImageUrl(imageSource, { width: 640, quality: 40, format: 'avif' })} 640w,
-    ${getOptimizedImageUrl(imageSource, { width: 960, quality: 40, format: 'avif' })} 960w
-  `.trim()
-
-  // WebP fallback srcset for Safari 15 and older (7% of users)
+  // WebP srcset - avif removed (Sanity CDN returns 400 for ?fm=avif, encoding on VPS adds 5s to LCP)
   const webpSrcSet = `
     ${getOptimizedImageUrl(imageSource, { width: 480, quality: 40, format: 'webp' })} 480w,
     ${getOptimizedImageUrl(imageSource, { width: 640, quality: 40, format: 'webp' })} 640w,
@@ -66,14 +49,7 @@ export function FirstImage({ design }: FirstImageProps) {
       suppressHydrationWarning
     >
       <picture>
-        {/* AVIF for modern browsers (30-40% better compression than WebP) */}
-        <source
-          type="image/avif"
-          srcSet={avifSrcSet}
-          sizes={sizes}
-        />
-
-        {/* WebP fallback for Safari 15 and older browsers */}
+        {/* WebP for modern browsers - avif removed (Sanity 400s on ?fm=avif) */}
         <source
           type="image/webp"
           srcSet={webpSrcSet}

--- a/src/components/server/__tests__/FirstImage.test.tsx
+++ b/src/components/server/__tests__/FirstImage.test.tsx
@@ -60,16 +60,16 @@ describe('FirstImage Server Component - Issue #266', () => {
       expect(picture).toBeInTheDocument()
     })
 
-    it('includes AVIF source for modern browsers', () => {
-      const { container } = render(<FirstImage design={mockDesign} />)
-      const avifSource = container.querySelector('source[type="image/avif"]')
-      expect(avifSource).toBeInTheDocument()
-    })
-
-    it('includes WebP source for Safari 15 fallback', () => {
+    it('includes WebP source for modern browsers', () => {
       const { container } = render(<FirstImage design={mockDesign} />)
       const webpSource = container.querySelector('source[type="image/webp"]')
       expect(webpSource).toBeInTheDocument()
+    })
+
+    it('does not include AVIF source (Sanity CDN returns 400 for ?fm=avif)', () => {
+      const { container } = render(<FirstImage design={mockDesign} />)
+      const avifSource = container.querySelector('source[type="image/avif"]')
+      expect(avifSource).not.toBeInTheDocument()
     })
 
     it('includes JPEG img element as final fallback', () => {
@@ -133,10 +133,8 @@ describe('FirstImage Server Component - Issue #266', () => {
 
       // Per HTML5 spec, <source> elements don't support crossorigin attribute
       // CORS policy is inherited from the fallback <img> element
-      const avifSource = container.querySelector('source[type="image/avif"]')
       const webpSource = container.querySelector('source[type="image/webp"]')
 
-      expect(avifSource).not.toHaveAttribute('crossorigin')
       expect(webpSource).not.toHaveAttribute('crossorigin')
     })
   })
@@ -146,18 +144,6 @@ describe('FirstImage Server Component - Issue #266', () => {
   // ========================================
 
   describe('Image URL Generation', () => {
-    it('generates AVIF srcset with correct widths (480w, 640w, 960w)', () => {
-      const { container } = render(<FirstImage design={mockDesign} />)
-
-      const avifSource = container.querySelector('source[type="image/avif"]')
-      const srcset = avifSource?.getAttribute('srcset')
-
-      expect(srcset).toContain('480w')
-      expect(srcset).toContain('640w')
-      expect(srcset).toContain('960w')
-      expect(srcset).toContain('avif')
-    })
-
     it('generates WebP srcset with correct widths (480w, 640w, 960w)', () => {
       const { container } = render(<FirstImage design={mockDesign} />)
 
@@ -187,8 +173,8 @@ describe('FirstImage Server Component - Issue #266', () => {
     it('applies responsive sizes attribute', () => {
       const { container } = render(<FirstImage design={mockDesign} />)
 
-      const avifSource = container.querySelector('source[type="image/avif"]')
-      const sizes = avifSource?.getAttribute('sizes')
+      const webpSource = container.querySelector('source[type="image/webp"]')
+      const sizes = webpSource?.getAttribute('sizes')
 
       expect(sizes).toContain('max-width: 480px')
       expect(sizes).toContain('max-width: 768px')


### PR DESCRIPTION
## Summary
- **Remove avif from Next.js image formats** (`formats: ['image/webp']`) — avif encoding via `sharp` on the VPS adds 5+ seconds to LCP on cold paths; webp encoding is 5-10x faster
- **Remove avif `<source>` from `FirstImage.tsx`** — Sanity CDN returns 400 for `?fm=avif`; replaced with webp-only `<picture>` element
- **Switch preload hints** in `page.tsx`, `projects/page.tsx`, `project/[slug]/page.tsx` from `type="image/avif"` to `type="image/webp"` so the preload matches the actual served format
- **Fix `MobileGalleryItem` aspect ratio hint**: `width=600 height=800` (portrait 3:4) was `width=800 height=600` (landscape 4:3) — mismatch was causing CLS (measured 0.127)
- **Update `FirstImage` tests**: remove avif assertions, assert avif source is absent

## Lighthouse Audit Findings (2026-03-09)
| Metric | Before | Expected After |
|---|---|---|
| Performance | 54 | ~65-75 |
| LCP | 6.5s ❌ | ~2-3s ✅ |
| CLS | 0.127 ⚠️ | ~0.05 ✅ |
| Console errors | 400 on avif | None |

## Root Cause
`/_next/image` with `formats: ['image/avif']` encodes images to avif on-demand using `sharp`. On the Vultr VPS, this CPU-intensive step was taking 5+ seconds per image. The `minimumCacheTTL: 31536000` caches subsequent requests but Lighthouse always tests cold paths.

Simultaneously, `FirstImage.tsx` was requesting `?fm=avif` directly from Sanity CDN, which returns HTTP 400 (not supported on this plan), causing browser retry cascade.

## Test Plan
- [x] All 1212 tests passing
- [x] `FirstImage` tests updated to assert webp-only structure
- [ ] Deploy to production and re-run Lighthouse to verify LCP improvement
- [ ] Confirm no console 400 errors after deploy

Fixes #342