### PR TITLE
fix(tests): type assertions for data-testid in BaseFormField tests

### DIFF
--- a/src/components/shared/Forms/__tests__/BaseFormField.test.tsx
+++ b/src/components/shared/Forms/__tests__/BaseFormField.test.tsx
@@ -335,7 +335,7 @@ describe('BaseFormField', () => {
           label="Name"
           type="text"
           classPrefix="desktop"
-          extraInputProps={{ autoComplete: 'name', 'data-testid': 'name-input' }}
+          extraInputProps={{ autoComplete: 'name', 'data-testid': 'name-input' } as React.InputHTMLAttributes<HTMLInputElement>}
         />
       )
 
@@ -349,7 +349,7 @@ describe('BaseFormField', () => {
           label="Message"
           type="textarea"
           classPrefix="desktop"
-          extraTextareaProps={{ 'data-testid': 'msg-textarea' }}
+          extraTextareaProps={{ 'data-testid': 'msg-textarea' } as React.TextareaHTMLAttributes<HTMLTextAreaElement>}
         />
       )
 


### PR DESCRIPTION
Fixes TS2353 — `data-testid` is a valid `data-*` attribute at runtime but TypeScript's excess property checking rejects it in object literals passed to typed props. Type assertions in the two affected tests silence the error without changing behaviour.

Unblocks deployment after the CI type-check failure triggered by the pre-existing issue.

Fixes #342