### PR TITLE
fix: add isPriority to MobileGalleryItem test type

### DIFF
--- a/SESSION_HANDOVER.md
+++ b/SESSION_HANDOVER.md
@@ -1,9 +1,10 @@
-# Session Handoff: Issue #363 — LCP Direct CDN Preload (IN PROGRESS)
+# Session Handoff: Issue #363 — LCP Direct CDN Preload (CLOSED) + PR #365 type fix
 
-**Date**: 2026-03-18
-**Issue**: #363 — perf: preload LCP image via direct Sanity CDN URL instead of /_next/image proxy
-**PR**: #364 — perf: preload LCP image via direct Sanity CDN URL — bypass /_next/image proxy (OPEN)
-**Branch**: perf/issue-363-lcp-direct-cdn-preload
+**Date**: 2026-03-19
+**Issue**: #363 — perf: preload LCP image via direct Sanity CDN URL instead of /_next/image proxy (CLOSED)
+**PR**: #364 — perf: preload LCP image via direct Sanity CDN URL — bypass /_next/image proxy (MERGED)
+**PR**: #365 — fix: add isPriority to MobileGalleryItem test type (OPEN — CI passing)
+**Branch**: fix/issue-363-test-type-ispriority
 
 ---
 
@@ -18,7 +19,7 @@ Diagnosed why home page CI Lighthouse LCP (5.7–9.0s) is so much worse than /ab
 - **Root cause**: preload in `page.tsx` pointed to `/_next/image?url=...` proxy URLs;
   `<Image>` fetched via proxy even though Sanity CDN already serves optimised WebP
 
-### 2. LCP Fix (Issue #363, PR #364 — OPEN)
+### 2. LCP Fix (Issue #363, PR #364 — MERGED ✅)
 
 **Two-file change:**
 
@@ -40,9 +41,16 @@ Diagnosed why home page CI Lighthouse LCP (5.7–9.0s) is so much worse than /ab
 - `page.test.tsx`: all 6 tests rewritten for new direct CDN preload; React 19 hoists
   `<link rel="preload">` to `document.head` — tests updated to query `document.head`
 
-**All 1206 unit tests passing** ✅
+### 3. Type Fix (PR #365 — OPEN, CI all green except session handoff)
 
-### 3. Context: Prior Session Work (2026-03-17)
+After PR #364 merged, Production Deployment CI failed — `npm run type-check` caught:
+```
+Property 'isPriority' does not exist on type 'IntrinsicAttributes & { design: TextileDesign }'
+```
+Root cause: local `ComponentType<{ design: TextileDesign }>` declaration in test file was missing `isPriority?: boolean`.
+Fix committed as `fad058b`, PR #365 open and passing all checks.
+
+### 4. Context: Prior Session Work (2026-03-17/18)
 
 - PR #354 (undici) + PR #351 (tar) — Dependabot security updates merged ✅
 - Issue #358 + PR #359 — production deploy race condition fixed (concurrency group) ✅
@@ -53,15 +61,13 @@ Diagnosed why home page CI Lighthouse LCP (5.7–9.0s) is so much worse than /ab
 ## 🎯 Current Project State
 
 **Tests**: ✅ 1206 passing (23 skipped)
-**Branch**: perf/issue-363-lcp-direct-cdn-preload
-**Production**: idaromme.dk — ✅ LIVE
-**PR #364**: ⏳ open — E2E + Lighthouse CI pending
+**Branch**: fix/issue-363-test-type-ispriority (PR #365 open)
+**Production**: idaromme.dk — ✅ LIVE (but Production Deployment failed post-#364 merge; pending PR #365 fix)
+**PR #365**: ✅ All CI checks passing (except session handoff — fixed by this update)
 
-### CI Status (PR #364)
-- ✅ Unit tests, Bundle size, Safari Smoke, Secret scan, Commit quality
-- ⏳ Playwright Desktop/Mobile Chrome pending
-- ⏳ Lighthouse Performance Budget pending
-- ❌ Verify Session Handoff (fixed by this update)
+### CI Status (PR #365)
+- ✅ Unit tests, Bundle size, E2E (Desktop/Mobile/Safari), Lighthouse, Secret scan, Commit quality
+- ✅ Verify Session Handoff (fixed by this update)
 
 ---
 
@@ -69,18 +75,19 @@ Diagnosed why home page CI Lighthouse LCP (5.7–9.0s) is so much worse than /ab
 
 | PR | Issue | Description |
 |----|-------|-------------|
+| #365 | #363 | fix: add isPriority to MobileGalleryItem test type |
 | #364 | #363 | perf: preload LCP via direct Sanity CDN — bypass /_next/image proxy |
 | #359 | #358 | fix: prevent concurrent production deployments — concurrency group |
 | #354 | — | build(deps): bump undici 6.23.0→6.24.1 (Dependabot) |
-| #351 | — | build(deps): bump tar 7.5.10→7.5.11 (Dependabot) |
 
 ---
 
 ## 🚀 Next Session Priorities
 
-1. **Merge PR #364** (if CI green): verify Lighthouse CI score improvement on home page
-2. **Verify production LCP**: run Lighthouse on idaromme.dk after deploy to confirm ≤1.7s
-3. **Issue #349 (optional)** — unused JS: vendor 132KB, framework 61KB
+1. **Merge PR #365** (CI green after this handoff commit): unblocks Production Deployment
+2. **Verify Production Deployment succeeds** after PR #365 merge
+3. **Verify production LCP**: run Lighthouse on idaromme.dk after deploy to confirm improvement
+4. **Issue #349 (optional)** — unused JS: vendor 132KB, framework 61KB
 
 ### Key Architecture Notes (carry-forward)
 - `MobileGalleryItem`: `unoptimized={isPriority}` — LCP image bypasses `/_next/image`
@@ -96,14 +103,14 @@ Diagnosed why home page CI Lighthouse LCP (5.7–9.0s) is so much worse than /ab
 ```
 Read CLAUDE.md to understand our workflow, then continue from Issue #363 completion.
 
-**Immediate priority**: Merge PR #364 if all CI checks green. Then verify Lighthouse CI
-  improvement on home page (expected: ~1.5–2s LCP reduction from direct CDN preload).
-**Context**: Issue #363 implemented — LCP image now fetches Sanity CDN directly
-  (unoptimized={isPriority} + matching preload href), bypassing /_next/image proxy.
+**Immediate priority**: Merge PR #365 (type fix, CI green), then verify Production Deployment
+  succeeds and Lighthouse shows LCP improvement on idaromme.dk home page.
+**Context**: Issue #363 merged (PR #364) — LCP image bypasses /_next/image proxy via
+  unoptimized={isPriority}. PR #365 fixes follow-up TypeScript type error in test file.
 **Reference docs**: SESSION_HANDOVER.md
-**Ready state**: perf/issue-363-lcp-direct-cdn-preload pushed, 1206 unit tests passing
+**Ready state**: fix/issue-363-test-type-ispriority branch pushed, all CI green on PR #365
 
-**Expected scope**: Merge PR #364, check Lighthouse results, optional Issue #349 bundle size
+**Expected scope**: Merge PR #365, confirm production deploy, verify LCP improvement, optional Issue #349
 ```
 
 ---

--- a/src/components/mobile/Gallery/__tests__/MobileGalleryItem.test.tsx
+++ b/src/components/mobile/Gallery/__tests__/MobileGalleryItem.test.tsx
@@ -44,6 +44,7 @@ jest.mock('@/utils/analytics', () => ({
 describe('MobileGalleryItem', () => {
   let MobileGalleryItem: React.ComponentType<{
     design: TextileDesign
+    isPriority?: boolean
   }>
 
   beforeAll(async () => {


### PR DESCRIPTION
## Summary
- Fixes TypeScript type-check error introduced by PR #364
- `MobileGalleryItem.test.tsx` declared `ComponentType<{ design: TextileDesign }>` without `isPriority?: boolean`, causing `npm run type-check` to fail in Production Deployment CI

## Root Cause
PR #364 added `isPriority` tests that pass `isPriority` as a prop, but the local `let MobileGalleryItem: React.ComponentType<...>` declaration was missing the prop type — the TypeScript compiler caught this during the production deploy `test` job.

## Fix
Added `isPriority?: boolean` to the `ComponentType` generic in the test file (matches the actual component interface).

Fixes #363 (follow-up type fix)